### PR TITLE
chore: Update jsonschema usage

### DIFF
--- a/trailbase-core/src/config.rs
+++ b/trailbase-core/src/config.rs
@@ -549,7 +549,7 @@ pub(crate) fn validate_config(
 
     let schema_json: serde_json::Value = serde_json::from_str(schema_text)
       .map_err(|err| ConfigError::Invalid(format!("Schema is invalid Json: {err}")))?;
-    if let Err(err) = jsonschema::Validator::new(&schema_json) {
+    if let Err(err) = jsonschema::meta::validate(&schema_json) {
       return Err(ConfigError::Invalid(format!(
         "Not a valid Json schema: {err}"
       )));

--- a/trailbase-core/src/table_metadata.rs
+++ b/trailbase-core/src/table_metadata.rs
@@ -48,10 +48,11 @@ impl JsonColumnMetadata {
       Self::Pattern(pattern) => {
         let schema =
           Validator::new(pattern).map_err(|err| JsonSchemaError::SchemaCompile(err.to_string()))?;
-        schema
-          .validate(value)
-          .map_err(|_err| JsonSchemaError::Validation)?;
-        return Ok(());
+        if !schema.is_valid(value) {
+          Err(JsonSchemaError::Validation)
+        } else {
+          Ok(())
+        }
       }
     }
   }

--- a/trailbase-extension/src/jsonschema.rs
+++ b/trailbase-extension/src/jsonschema.rs
@@ -11,15 +11,6 @@ use std::sync::LazyLock;
 
 pub type ValidationError = jsonschema::ValidationError<'static>;
 
-fn validation_error_into_owned(err: jsonschema::ValidationError<'_>) -> ValidationError {
-  ValidationError {
-    instance_path: err.instance_path.clone(),
-    instance: std::borrow::Cow::Owned(err.instance.into_owned()),
-    kind: err.kind,
-    schema_path: err.schema_path,
-  }
-}
-
 type CustomValidatorFn = Arc<dyn Fn(&serde_json::Value, Option<&str>) -> bool + Send + Sync>;
 
 #[derive(Clone)]
@@ -34,7 +25,7 @@ impl SchemaEntry {
     schema: serde_json::Value,
     custom_validator: Option<CustomValidatorFn>,
   ) -> Result<Self, ValidationError> {
-    let validator = Validator::new(&schema).map_err(|err| validation_error_into_owned(err))?;
+    let validator = Validator::new(&schema)?;
 
     return Ok(Self {
       schema,


### PR DESCRIPTION
Hey!

This PR updates some usages of the `jsonschema` crate including the recent `meta` API which is dedicated to meta-schema validation (and is substantially faster than creating a new validator via `Validator::new`). Also, `validation_error_into_owned` is not needed anymore, as `Validator::new` returns `ValidationError<'static>` + there is the `ValidationError::to_owned` method which does exactly what `validation_error_into_owned` was doing.

Another small detail is that I've noticed that the actual validation error is ignored in `JsonColumnMetadata::validate`, so I replaced it with `is_valid` which is usually significantly faster for invalid instances.