### PR TITLE
Fix: Simplify the docker setup

### DIFF
--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -67,6 +67,17 @@ Default users:
 
 ## Instructions
 
+### Get up and running with Docker Compose in under 2 minutes
+
+```bash
+cd $REPO/examples/blog
+docker compose build
+docker compose up
+# Visit https://localhost and ignore the SSL error
+```
+
+### Building each piece of this example project
+
 Generally speaking, there are roughly 2.5 moving parts to run the example, i.e:
 we have to build the web UI, start the TrailBase server, and optionally start
 the Flutter app. Once you have `cargo`, `pnpm`, and `flutter` installed, you

--- a/examples/blog/docker-compose.yml
+++ b/examples/blog/docker-compose.yml
@@ -1,14 +1,9 @@
 services:
 
   blog:
-    # NOTE: We have to build relative to root to have a build context that
-    # includes both: the trailbase server source and the demo wepapp sources.
-    # build: ../..
-    # TODO: Build from "." once the Dockerfile can pull a base image from
-    # dockerhub. We still need an example Dockerfile to build the UI.
     build:
-      context: ../..
-      dockerfile: examples/blog/Dockerfile
+      context: .
+      dockerfile: Dockerfile
     restart: unless-stopped
     environment:
       TRAIL_INITIAL_PASSWORD: secret

--- a/examples/blog/web/package.json
+++ b/examples/blog/web/package.json
@@ -21,7 +21,7 @@
     "nanostores": "^0.11.4",
     "solid-icons": "^1.1.0",
     "solid-js": "^1.9.5",
-    "trailbase": "workspace:*"
+    "trailbase": "^0.3.3"
   },
   "devDependencies": {
     "@astrojs/solid-js": "^5.0.5",


### PR DESCRIPTION
Feel free to ignore this suggestion, but I really just wanted to start this up with docker and see it in action, but the docs don't describe the best way to do this. 

I also ran into an error where `docker compose build` looks for ./traildepot in the local path, but can't find it with the relative path pointing to two levels up. I just went ahead and fixed it to build from the example/blog directory, but there may be a better way to do this.

