### PR TITLE
Change the order so that alias of `trail` works properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ curl -sSL https://raw.githubusercontent.com/trailbaseio/trailbase/main/install.s
 Alternatively, run TrailBase using the Docker image:
 
 ```sh
+mkdir traildepot &&
 alias trail='
-  mkdir traildepot && \
   docker run \
       --network host \
       --mount type=bind,source="$PWD"/traildepot,target=/app/traildepot \

--- a/docs/src/content/docs/getting-started/_install_oneliners.mdx
+++ b/docs/src/content/docs/getting-started/_install_oneliners.mdx
@@ -5,8 +5,8 @@ export const installWindows = `iwr https://raw.githubusercontent.com/trailbaseio
 export const installDocker= `
 # Docker is used here merely as an easy, portable way to install TrailBase.
 # To make this persistent, you'll have to add the alias to your shell's rc.
+mkdir traildepot &&
 alias trail='
-  mkdir traildepot && \\
   docker run \\
       --network host \\
       --mount type=bind,source="$PWD"/traildepot,target=/app/traildepot \\


### PR DESCRIPTION
Correct a minor typo? Currently, running the trail alias repeatedly executes mkdir traildepot, which prevents the command from working properly.