### PR TITLE
Fix: make OAuth login in examples/blog/flutter work

### DIFF
--- a/examples/blog/flutter/android/app/src/main/AndroidManifest.xml
+++ b/examples/blog/flutter/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
-            android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
@@ -23,6 +22,16 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="com.linusu.flutter_web_auth_2.CallbackActivity"
+            android:exported="true">
+            <intent-filter android:label="flutter_web_auth_2">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="trailbase-example-blog" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/examples/blog/flutter/lib/main.dart
+++ b/examples/blog/flutter/lib/main.dart
@@ -17,6 +17,7 @@ Future<void> main() async {
         '${record.level.name}: ${record.time}  ${record.loggerName}: ${record.message}');
   });
 
+  WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
 
   final tokensJson = prefs.getString(_tokensKey);


### PR DESCRIPTION
Was playing with the blog example app to learn how auth works in TB and had to fix some problems before OAuth started working there:

- The app didn't register its custom uri scheme trailbase-example-blog so flutter_web_auth_2 couldn't extract the authorization code from redirect. Fix by adding an activity to AndroidManifest.xml per flutter_web_auth_2 instructions.

- After extracting the code from redirect uri, flutter_web_auth_2 didn't close the browser tab. Remove android:taskAffinity="" per https://github.com/ThexXTURBOXx/flutter_web_auth_2/commit/73f91891ee017d280dab02710f41ecaa9ee97a0b

- The app failed with exception right at start b/c SharedPreferences accessed flutter before it was fully inited. Init flutter with WidgetsFlutterBinding.ensureInitialized() before using prefs.

- Another one was TB returned "Invalid redirect" for a custom uri scheme. For that, created issue #100.