### PR TITLE
Draft: Update PRAGMAs for Consideration

### DIFF
--- a/crates/extension/src/lib.rs
+++ b/crates/extension/src/lib.rs
@@ -21,32 +21,21 @@ pub enum Error {
 }
 
 pub fn apply_default_pragmas(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
-  const CONFIG: &[&str] = &[
-    "PRAGMA busy_timeout       = 10000",
-    "PRAGMA journal_mode       = WAL",
-    "PRAGMA journal_size_limit = 200000000",
-    // Sync the file system less often.
-    "PRAGMA synchronous        = NORMAL",
-    "PRAGMA foreign_keys       = ON",
-    "PRAGMA temp_store         = MEMORY",
-    "PRAGMA cache_size         = -16000",
-    // TODO: Maybe worth exploring once we have a benchmark, based on
-    // https://phiresky.github.io/blog/2020/sqlite-performance-tuning/.
-    // "PRAGMA mmap_size          = 30000000000",
-    // "PRAGMA page_size          = 32768",
-
-    // Safety feature around application-defined functions recommended by
-    // https://sqlite.org/appfunc.html
-    "PRAGMA trusted_schema     = OFF",
-  ];
-
-  // NOTE: we're querying here since some pragmas return data.
-  for pragma in CONFIG {
-    // TODO: Use conn.pragma_update instead.
-    let mut stmt = conn.prepare(pragma)?;
-    let mut rows = stmt.query([])?;
-    let _maybe_row = rows.next()?;
-  }
+  conn.pragma_update(None, "busy_timeout", 10000)?;
+  conn.pragma_update(None, "journal_mode", "WAL")?;
+  conn.pragma_update(None, "journal_size_limit", 200000000)?;
+  // Sync the file system less often.
+  conn.pragma_update(None, "synchronous", "NORMAL")?;
+  conn.pragma_update(None, "foreign_keys", "ON")?;
+  conn.pragma_update(None, "temp_store", "MEMORY")?;
+  // TODO: we should consider moving this to each database init
+  // in (init_main_db & init_logs_db)
+  conn.pragma_update(None, "cache_size", -16000)?;
+  // Keep SQLite default 4KB page_size
+  // conn.pragma_update(None, "page_size", 4096)?;
+  // Safety feature around application-defined functions recommended by
+  // https://sqlite.org/appfunc.html
+  conn.pragma_update(None, "trusted_schema", "OFF")?;
 
   return Ok(());
 }
@@ -85,7 +74,7 @@ pub fn connect_sqlite(
   apply_default_pragmas(&conn)?;
 
   // Initial optimize.
-  conn.execute("PRAGMA optimize = 0x10002", ())?;
+  conn.pragma_update(None, "optimize", "0x10002")?;
 
   return Ok(conn);
 }


### PR DESCRIPTION
**_This is for discussion only until real benchmarks are carried out._**

Current Trailbase memory usage is ~90–150 MB under load, with sub-millisecond latencies. However, the two databases it manages have different characteristics:

- **Main database** — Handles diverse record operations and can benefit from moderate caching and memory mapping without excessive memory growth.
- **Logs database** — Write-heavy, doesn’t benefit from large caches. Current configuration seems sufficient.

**Current setup:**
- Cache size: **16 MB** per database → **32 MB** total dedicated to SQLite caches.
- This [makes it suitable for a tiny VPS or a toaster](https://trailbase.io/reference/benchmarks/#utilization).

**Proposed change:**
- **Main database:** Test incremental increases in cache and memory mapping sizes, for example:
  1. 32 MB cache + 64 MB MMAP → Estimated memory use: **112 MB total** (Main DB = **96 MB** + Logs DB = **16 MB**)
  2. 64 MB cache + 128 MB MMAP → Estimated memory use: **208 MB total** (Main DB = **192 MB** + Logs DB = **16 MB**)
  3. 128 MB cache + 256 MB MMAP → Estimated memory use: **400 MB total** (Main DB = **384 MB** + Logs DB = **16 MB**)
- **Logs database:** Keep existing 16 MB cache.
- **Expected impact:** _Potentially_ faster queries and record operations for the main database, but requires benchmarking to confirm.

**Notes:** PRAGMA tuning could be made optional via configuration so small systems can retain the current low-memory defaults.

**Related roadmap context:** Trailbase plans to support many SQLite databases.  
This should be taken into consideration for overall memory footprint as each database will have its own cache and memory mapping settings.
