### PR TITLE
Fix CompareOp Regex

### DIFF
--- a/client/go/trailbase/record_api.go
+++ b/client/go/trailbase/record_api.go
@@ -140,7 +140,7 @@ func (op CompareOp) toString() string {
 	case Like:
 		return "$like"
 	case Regex:
-		return "re"
+		return "$re"
 	default:
 		panic(fmt.Sprint("Unknown operation:", op))
 	}


### PR DESCRIPTION
Hello,

I think it was misspelled, should be `$re` instead of `re`?