### PR TITLE
fix: respond to subscribe stat

### DIFF
--- a/crates/core/src/records/subscribe.rs
+++ b/crates/core/src/records/subscribe.rs
@@ -549,7 +549,7 @@ impl SubscriptionManager {
         record_api_name: api.api_name().to_string(),
         // record_id: Some(record),
         user,
-        sender,
+        sender: sender.clone(),
       });
 
       empty
@@ -561,6 +561,11 @@ impl SubscriptionManager {
         .await
         .map_err(|err| RecordError::Internal(err.into()))?;
     }
+
+    // Send an immediate comment to flush SSE headers and establish the connection
+    let _ = sender
+      .send(Event::default().comment("subscription established"))
+      .await;
 
     return Ok(AutoCleanupEventStream {
       cleanup: CleanupSubscription {
@@ -595,7 +600,7 @@ impl SubscriptionManager {
         subscription_id,
         record_api_name: api.api_name().to_string(),
         user,
-        sender,
+        sender: sender.clone(),
       });
 
       empty
@@ -607,6 +612,11 @@ impl SubscriptionManager {
         .await
         .map_err(|err| RecordError::Internal(err.into()))?;
     }
+
+    // Send an immediate comment to flush SSE headers and establish the connection
+    let _ = sender
+      .send(Event::default().comment("subscription established"))
+      .await;
 
     return Ok(AutoCleanupEventStream {
       cleanup: CleanupSubscription {


### PR DESCRIPTION
The TanStack/db and TrailBase integration was experiencing a 15-second delay (e.g., in the tanstack-db-sync example) during initial data loading because:

1. TanStack/db correctly establishes the subscription before fetching initial data (good for avoiding race conditions)
2. The client waits for the SSE connection to be "ready" before proceeding
3. The server wasn't sending any immediate response, so the client waited for the first keepalive message
4. The keepalive interval was 15 seconds, causing the delay

The Fix: Send Immediate SSE Comment

When a subscription is established, we now send an immediate SSE comment to flush the response headers:

```rust
// In add_record_subscription() and add_table_subscription()
// Send an immediate comment to flush SSE headers and establish the connection
let _ = sender
  .send(Event::default().comment("subscription established"))
  .await;
```

This ensures the client immediately knows the subscription is ready without waiting for a keepalive.