### PR TITLE
Add Base64 File Upload Support

### DIFF
--- a/client/testfixture/config.textproto
+++ b/client/testfixture/config.textproto
@@ -50,6 +50,11 @@ record_apis: [{
   table_name: "comment"
   acl_world: [READ]
   expand: ["author", "post"]
+}, {
+  name: "file_upload_table"
+  table_name: "file_upload_table"
+  acl_world: [CREATE, READ, DELETE]
+  acl_authenticated: [CREATE, READ, UPDATE, DELETE]
 }]
 schemas: [{
   name: "simple_schema"

--- a/client/testfixture/migrations/U1758448960__create_file_upload_table.sql
+++ b/client/testfixture/migrations/U1758448960__create_file_upload_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS file_upload_table (
+  id             BLOB PRIMARY KEY NOT NULL CHECK(is_uuid_v7(id)) DEFAULT(uuid_v7()),
+  single_file    TEXT CHECK(jsonschema('std.FileUpload', single_file)),
+  multiple_files TEXT CHECK(jsonschema('std.FileUploads', multiple_files)),
+  name           TEXT
+) STRICT;

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [
 ]
 
 [dependencies]
+base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 eventsource-stream = { version = "0.2.3", features = [] }
 futures-lite = "2.6.1"
 jsonwebtoken = { version = "9.3.0", default-features = false }

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -22,6 +22,7 @@ rusqlite = { workspace = true }
 schemars = "1.0.0"
 serde = { version = "^1.0.203", features = ["derive"] }
 serde_json = "1.0.122"
+serde-value = "0.7.0"
 sqlite3-parser = "0.15.0"
 thiserror = "2.0.12"
 tokio = { workspace = true }


### PR DESCRIPTION
Hello,

This PR adds support for uploading files as base64-encoded strings in JSON requests, complementing the existing multipart form upload functionality.

