### PR TITLE
fix!: remove wasm references when wasm feature disabled

### DIFF
--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -323,7 +323,7 @@ fn init_main_db_impl(
   data_dir: Option<&DataDir>,
   json_registry: Option<Arc<RwLock<JsonSchemaRegistry>>>,
   attach: Vec<AttachedDatabase>,
-  runtimes: Vec<SqliteFunctionRuntime>,
+  #[cfg_attr(not(feature = "wasm"), expect(unused))] runtimes: Vec<SqliteFunctionRuntime>,
   main_migrations: bool,
 ) -> Result<(Connection, bool), ConnectionError> {
   let main_path = data_dir.map(|d| d.main_db_path());

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -55,6 +55,7 @@ mod wasm {
     }
   }
 
+  #[derive(Clone)]
   pub struct SqliteFunctionRuntime;
 
   pub struct WasmRuntimeResult {
@@ -77,7 +78,7 @@ mod wasm {
 
   pub fn build_sync_wasm_runtimes_for_components(
     _components_path: PathBuf,
-    _fs_root_path: Option<PathBuf>,
+    _fs_root_path: Option<&std::path::Path>,
     _dev: bool,
   ) -> Result<Vec<SqliteFunctionRuntime>, AnyError> {
     return Ok(vec![]);


### PR DESCRIPTION
Thís is very rough cut to fix #174 it at least ensures that it no longer fails to compile.