### PR TITLE
docs: added uuid setting example

### DIFF
--- a/docs/src/content/docs/documentation/apis_record.mdx
+++ b/docs/src/content/docs/documentation/apis_record.mdx
@@ -19,8 +19,8 @@ For your data to be exposed via _Record APIs_:
   all the way from your DB records, over JSON schemas, to your client-side
   language bindings[^2].
 - To allow for stable sorting and thus efficient cursor-based pagination,
-  `TABLE`s are required to have either `INTEGER`, UUIDv4 or UUIDv7 [see definition example](https://github.com/trailbaseio/trailbase/blob/f84f6f42e6a740ffad14f4d1787ebb77cca9ab8e/crates/extension/src/uuid.rs#L93) primary key
-  columns.
+  `TABLE`s are required to have either `INTEGER`, UUIDv4 or UUIDv7 primary key
+  columns. [UUID definition example](https://github.com/trailbaseio/trailbase/blob/f84f6f42e6a740ffad14f4d1787ebb77cca9ab8e/crates/extension/src/uuid.rs#L93)
 
 ## Configuration
 


### PR DESCRIPTION
standard sqlite does not have uuid, since trailbase adds it's own uuid function, it should be properly documented how to define it.