### PR TITLE
Blog example: Increase Node version to 22 in Dockerfile

### DIFF
--- a/examples/blog/Dockerfile
+++ b/examples/blog/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim AS builder
+FROM node:22-slim AS builder
 
 RUN npm install -g pnpm
 RUN pnpm --version


### PR DESCRIPTION
The used `Astro` does not support node `v20` anymore. So we bump the version to `v22`

fixes #223