### PR TITLE
Install rustls CryptoProvider unconditionally on server boot

### DIFF
--- a/crates/core/src/server/mod.rs
+++ b/crates/core/src/server/mod.rs
@@ -692,6 +692,18 @@ pub async fn serve(
   admin_router: Option<(String, Router)>,
   tls: Option<(CertificateDer<'static>, PrivateKeyDer<'static>)>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  // Install the process-level rustls CryptoProvider unconditionally. Since
+  // rustls 0.23.39 there is no implicit default; any rustls client (e.g.
+  // outbound HTTPS from a WASM guest via wasi:http) panics with
+  // "Could not automatically determine the process-level CryptoProvider"
+  // unless `install_default()` has been called first. Previously this was
+  // done only inside the TLS-server branch of `start_listen`, so any
+  // deployment terminating TLS at an external reverse-proxy (HTTP plain
+  // upstream) and exercising HTTPS from the WASM runtime panicked at the
+  // first outbound request. Returning Err here just means the provider
+  // is already installed (e.g. from tests), which is fine.
+  let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+
   let has_tls = tls.is_some();
   let addr = main_router.0.clone();
   let admin_addr = admin_router
@@ -746,15 +758,13 @@ async fn start_listen(
       serve::serve(
         serve::TlsListener {
           listener: tcp_listener,
-          acceptor: TlsAcceptor::from(Arc::new({
-            tokio_rustls::rustls::crypto::aws_lc_rs::default_provider()
-              .install_default()
-              .expect("Failed to install rustls crypto");
+          acceptor: TlsAcceptor::from(Arc::new(
+            // Provider has been installed unconditionally in `serve()` above.
             ServerConfig::builder()
               .with_no_client_auth()
               .with_single_cert(vec![cert], key)
-              .expect("Failed to build server config")
-          })),
+              .expect("Failed to build server config"),
+          )),
         },
         router.into_make_service_with_connect_info::<SocketAddr>(),
       )


### PR DESCRIPTION
## Problem

`install_default()` is currently called only inside the **TLS-server branch** of `start_listen` ([crates/core/src/server/mod.rs#L754](https://github.com/trailbaseio/trailbase/blob/v0.27.0/crates/core/src/server/mod.rs#L754)). Since [rustls 0.23.39](https://github.com/rustls/rustls/blob/main/CHANGELOG.md) the implicit default crypto provider has been removed, so any rustls client (notably `wasi:http` outbound HTTPS from a WASM guest) panics with:

```
thread 'WASM' panicked at rustls-0.23.40/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from
Rustls crate features.
Call CryptoProvider::install_default() before this point to select a
provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring'
features is enabled.
```

The combination required to hit this is:
1. TrailBase deployed behind an **external reverse proxy** (Caddy, nginx, …) terminating TLS, with **HTTP plain upstream** to the TrailBase container — i.e. no `--tls-cert`/`--tls-key`.
2. A WASM HTTP handler that issues an outbound HTTPS `fetch()` (e.g. SMTP-via-microservice, third-party API call, payment provider).

In that configuration the TLS branch is never executed, the provider is never installed, and the very first outbound HTTPS request panics the worker. Working around it by enabling in-process TLS is awkward when an external proxy already handles certificates.

## Repro

Minimal sequence:
1. `trail run` (no `--tls-*` flags).
2. Deploy a WASM HTTP handler that calls `fetch("https://example.com/")`.
3. Hit the handler. Logs:

```
[WARN  trailbase::wasm] `Error calling WASM component - call_incoming_http_handler` returned: Other: task <N> panicked with message "child task panicked: JoinError::Panic(...,
\"Could not automatically determine the process-level CryptoProvider...\")"
```

This was hit on `0.26.5` through `0.27.0` in production, against a setup where TLS is terminated by Caddy and the WASM guest issues outbound HTTPS for transactional flows. `0.26.4` works because rustls < 0.23.39 still had a feature-flag default fallback.

## Fix

Move `install_default()` to the top of the outer `serve()` function so it runs **once at boot**, regardless of the TLS server-side branch, and ignore the `Err` returned when the provider is already installed (e.g. from tests).

```rust
let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
```

The previous TLS-branch invocation is removed (the provider is now guaranteed to be installed by the time `start_listen` runs). The `Err`-on-double-install is benign per [rustls docs for `CryptoProvider::install_default`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default).

## Notes

- No new dependency, no API change.
- Comment block above the call documents the rationale so it isn't moved back during a future refactor.
- I did not find any existing issue or PR mentioning rustls / CryptoProvider in the tracker; happy to file one alongside if you'd prefer that workflow.