### PR TITLE
fix: skip stored FileUpload format in PATCH requests

### DIFF
--- a/crates/core/src/records/params.rs
+++ b/crates/core/src/records/params.rs
@@ -266,6 +266,23 @@ impl Params {
         continue;
       };
 
+      // For file upload columns in PATCH requests: if the client echoes back the stored
+      // FileUpload/FileUploads format (no 'data' field), skip the column entirely rather
+      // than returning an error. This preserves the existing file without modification,
+      // which is the expected behavior when a client round-trips a record through the API.
+      if let Some(JsonColumnMetadata::SchemaName(schema_name)) = json.as_ref() {
+        let is_stored_upload = match (schema_name.as_str(), &value) {
+          ("std.FileUpload", serde_json::Value::Object(map)) => !map.contains_key("data"),
+          ("std.FileUploads", serde_json::Value::Array(items)) => items
+            .iter()
+            .all(|v| matches!(v, serde_json::Value::Object(m) if !m.contains_key("data"))),
+          _ => false,
+        };
+        if is_stored_upload {
+          continue;
+        }
+      }
+
       let (param, json_files) = extract_params_and_files_from_json(
         json_schema_registry,
         column,
@@ -891,5 +908,107 @@ mod tests {
         }),
       );
     }
+  }
+
+  #[tokio::test]
+  async fn test_for_update_skips_stored_file_upload() {
+    let registry = trailbase_schema::registry::build_json_schema_registry(vec![]).unwrap();
+
+    let sql = r#"
+      CREATE TABLE records (
+        id BLOB PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        avatar TEXT CHECK(jsonschema('std.FileUpload', avatar))
+      )
+    "#;
+
+    let table: Table = parse_into_statement(sql)
+      .unwrap()
+      .unwrap()
+      .try_into()
+      .unwrap();
+
+    let metadata = TableMetadata::new(&registry, table.clone(), &[table]).unwrap();
+
+    let id: [u8; 16] = uuid::Uuid::now_v7().as_bytes().clone();
+
+    // Test: stored FileUpload format in PATCH body (no 'data' field) should be skipped.
+    // This happens when TanStack DB or any client reads a record and echoes back the stored
+    // file reference in a PATCH request without intending to upload a new file.
+    let value = json!({
+      "name": "Alice",
+      "avatar": {
+        "filename": "avatar_abc123.jpg",
+        "original_filename": "avatar.jpg",
+        "content_type": "image/jpeg",
+        "mime_type": "image/jpeg"
+      }
+    });
+
+    let params = Params::for_update(
+      &metadata,
+      &registry,
+      json_row_from_value(value).unwrap(),
+      None,
+      "id".to_string(),
+      Value::Blob(id.to_vec()),
+    )
+    .unwrap();
+
+    let Params::Update {
+      named_params: _,
+      column_names,
+      ..
+    } = params
+    else {
+      panic!("Expected Update params");
+    };
+
+    // Avatar column should be skipped (not in the UPDATE clause).
+    assert!(
+      !column_names.contains(&"avatar".to_string()),
+      "Stored FileUpload should be skipped in PATCH, but column_names = {column_names:?}"
+    );
+
+    // Non-file columns should still be included.
+    assert!(
+      column_names.contains(&"name".to_string()),
+      "Non-file columns should still be included, but column_names = {column_names:?}"
+    );
+
+    // Test: FileUploadInput with 'data' field should NOT be skipped.
+    let png_data = BASE64_URL_SAFE.encode([137u8, 80, 78, 71]);
+    let value_with_new_file = json!({
+      "name": "Bob",
+      "avatar": {
+        "filename": "new_avatar.jpg",
+        "content_type": "image/jpeg",
+        "data": png_data
+      }
+    });
+
+    let params_with_file = Params::for_update(
+      &metadata,
+      &registry,
+      json_row_from_value(value_with_new_file).unwrap(),
+      None,
+      "id".to_string(),
+      Value::Blob(id.to_vec()),
+    )
+    .unwrap();
+
+    let Params::Update {
+      column_names: col_names_with_file,
+      ..
+    } = params_with_file
+    else {
+      panic!("Expected Update params");
+    };
+
+    // Avatar should be present when there IS a 'data' field (new upload).
+    assert!(
+      col_names_with_file.contains(&"avatar".to_string()),
+      "New FileUploadInput with data should be included in PATCH, but column_names = {col_names_with_file:?}"
+    );
   }
 }


### PR DESCRIPTION
Fixes #233

## Problem

When a client performs a PATCH request where a `std.FileUpload` or `std.FileUploads` column contains the **stored** file reference format (the JSON returned by a GET — which has `filename`, `mime_type`, etc. but **no** `data` field), the request fails with `400 invalid params`.

This happens because `extract_params_and_files_from_json` tries to deserialize the value as `FileUploadInput`, which has `#[serde(deny_unknown_fields)]` and requires a non-optional `data: Vec<u8>` field. The stored `FileUpload` format has `mime_type` (unknown field) and no `data`, so deserialization fails.

### Reproduction

```
GET /api/records/v1/user_profiles/{id}
→ { "avatar": { "filename": "abc.jpg", "mime_type": "image/jpeg", ... } }

PATCH /api/records/v1/user_profiles/{id}
  { "display_name": "New Name", "avatar": { "filename": "abc.jpg", "mime_type": "image/jpeg", ... } }
→ 400 "invalid params"
```

This is a common pattern for any client that reads a record and sends back a partial update (e.g. TanStack DB, which sends only changed fields but includes the full current values of unchanged fields in the `changes` delta).

## Fix

In `Params::for_update`, before calling `extract_params_and_files_from_json`, detect the stored format by checking for the **absence of a `data` field** in the JSON value:

- `std.FileUpload`: if value is an Object without a `"data"` key → skip the column (keep existing file)
- `std.FileUploads`: if value is an Array where all items are Objects without `"data"` keys → skip the column (keep existing files)

When skipped, the column is simply not included in the UPDATE statement, so the existing file reference in the database is preserved unchanged.

This makes PATCH semantics consistent: fields absent from the PATCH body are left unchanged, and file fields echoed back in their stored format behave the same way.

## Invariants preserved

- **INSERT** (`for_insert`): unchanged — new uploads still require `data`
- **PATCH with new file** (`for_update` + `data` present): unchanged — new file upload replaces existing
- **PATCH without file field**: unchanged — column not in body is not updated
- **PATCH with stored format** (new behavior): column is skipped, existing file preserved

## Test

Added `test_for_update_skips_stored_file_upload` in `crates/core/src/records/params.rs` that verifies:
1. PATCH with stored `FileUpload` format (no `data`) → column skipped, no error
2. PATCH with new `FileUploadInput` (with `data`) → column included, file uploaded