### PR TITLE
Fix spelling in `pocketbase.mdx`

### DIFF
--- a/docs/src/content/docs/comparison/pocketbase.mdx
+++ b/docs/src/content/docs/comparison/pocketbase.mdx
@@ -82,7 +82,7 @@ Expect TrailBase to improve significantly in this area.
 
 ### Features
 
-Looking more closely at the breadth of similar features, varioud differences
+Looking more closely at the breadth of similar features, various differences
 emerge.
 In lieu of trying to enumerating all of these constantly evolving differences,
 let's look a some of the nifty tricks that TrailBase has up its sleeve:


### PR DESCRIPTION
I was reviewing the docs and came across this misspelling, so I'm sending this patch over in case you find it useful.

Great project!