### PR TITLE
[draft] fix: allow use as library dependency without git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "vendor/sqlite-vec"]
 	path = vendor/sqlite-vec
 	url = https://github.com/ignatz/sqlite-vec.git
-[submodule "vendor/serde_rusqlite"]
-	path = vendor/serde_rusqlite
-	url = https://github.com/ignatz/serde_rusqlite.git
 [submodule "vendor/pgrow2serde"]
 	path = vendor/pgrow2serde
 	url = https://github.com/ignatz/pgrow2serde.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6780,16 +6780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6869,12 +6859,12 @@ dependencies = [
 
 [[package]]
 name = "serde_rusqlite"
-version = "0.38.0"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f51ff08953caf83bbd0d9be7ee58d41f1d1adc19a2e84c43f83ca50258571e"
 dependencies = [
  "rusqlite",
- "serde",
- "serde_bytes",
- "serde_derive",
+ "serde_core",
 ]
 
 [[package]]
@@ -7147,7 +7137,6 @@ name = "sqlite-vec"
 version = "0.1.10-alpha.4"
 dependencies = [
  "cc",
- "rusqlite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ rust-embed = { version = "8.4.0", default-features = false, features = ["mime-gu
 serde = { version = "^1.0.203", features = ["derive", "rc"] }
 serde_json = { version = "^1.0.117" }
 serde_qs = { version = "1.0.0", default-features = false, features = [] }
-serde_rusqlite = { path = "vendor/serde_rusqlite" }
-sqlite-vec = { path = "vendor/sqlite-vec/bindings/rust", default-features = false }
+serde_rusqlite = "0.43.0"
+sqlite-vec = { git = "https://github.com/ignatz/sqlite-vec", rev = "main", default-features = false }
 sqlite3-parser = "0.16.0"
 tokio = { version = "^1.38.0", default-features = false, features = ["fs", "io-std", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-rustls = { version = "0.26.1", default-features = false }
@@ -84,7 +84,7 @@ trailbase-build = { path = "crates/build", version = "0.1.1" }
 trailbase-client = { path = "crates/client", version = "0.8.0" }
 trailbase-extension = { path = "crates/extension", version = "0.3.0" }
 trailbase-pg-schema = { path = "crates/pg-schema", version = "0.0.1" }
-trailbase-pgrow2serde = { path = "vendor/pgrow2serde" }
+trailbase-pgrow2serde = { git = "https://github.com/ignatz/pgrow2serde", rev = "main" }
 trailbase-qs = { path = "crates/qs", version = "0.1.0" }
 trailbase-reactive = { path = "crates/reactive", version = "0.1.0" }
 trailbase-refinery = { path = "crates/refinery", version = "0.1.0" }
@@ -101,3 +101,14 @@ wasmtime = { version = "45.0.0", features = ["winch"] }
 wasmtime-wasi = { version = "45.0.0", default-features = false, features = [] }
 wasmtime-wasi-http = { version = "45.0.0", features = [] }
 wasmtime-wasi-io = { version = "45.0.0", features = [] }
+
+# When building TrailBase as a standalone workspace, use local submodule paths.
+# These [patch] sections are ignored when TrailBase is consumed as a dependency
+# by an external workspace (e.g. via git subtree without submodules populated),
+# which falls back to the git sources declared above.
+
+[patch."https://github.com/ignatz/sqlite-vec"]
+sqlite-vec = { path = "vendor/sqlite-vec/bindings/rust" }
+
+[patch."https://github.com/ignatz/pgrow2serde"]
+trailbase-pgrow2serde = { path = "vendor/pgrow2serde" }


### PR DESCRIPTION
## Problem

When TrailBase is consumed as a library from an external workspace (e.g. via `git subtree`), the build fails because:

1. `sqlite-vec` and `pgrow2serde` are path dependencies pointing to unpopulated git submodules.
2. `serde_rusqlite` uses `rusqlite = { workspace = true }`, which requires TrailBase to be the active workspace root — this breaks when resolved from outside.

## Solution

Replace the three sub-dependencies with sources that work standalone, while keeping `[patch]` entries so local submodule paths are still used when building TrailBase directly.

Since `[patch]` is only applied from the root workspace, contributors with submodules populated see no change in behavior.