### PR TITLE
fix: remove escaped quotes in register_totp_confirm UPDATE query

### DIFF
--- a/crates/core/src/auth/api/totp.rs
+++ b/crates/core/src/auth/api/totp.rs
@@ -111,7 +111,7 @@ pub async fn register_totp_confirm_handler(
   }
 
   const UPDATE_QUERY: &str =
-    formatcp!(r#"UPDATE \"{USER_TABLE}\" SET totp_secret = $1 WHERE id = $2"#);
+    formatcp!(r#"UPDATE "{USER_TABLE}" SET totp_secret = $1 WHERE id = $2"#);
 
   let user_id_bytes = user.uuid.into_bytes().to_vec();
   let secret = totp.get_secret_base32();


### PR DESCRIPTION
auth/api/totp.rs` used `\"` inside a raw string literal for the `UPDATE _user SET totp_secret` query. SQLite received literal backslash-quote characters instead of column quotes, causing the query to fail with a syntax error when enabling TOTP.

Change the `UPDATE_QUERY` constant in `register_totp_confirm_handler` to use unquoted
double-quotes (`"`) consistent with the adjacent `unregister_totp_handler`.

https://github.com/trailbaseio/trailbase/issues/208