### PR TITLE
Fix: JS client deleteUser() sends GET instead of DELETE

### DIFF
--- a/crates/assets/js/client/src/client.ts
+++ b/crates/assets/js/client/src/client.ts
@@ -377,7 +377,9 @@ class ClientImpl implements Client {
   }
 
   public async deleteUser(): Promise<void> {
-    await this.fetch(`${authApiBasePath}/delete`);
+    await this.fetch(`${authApiBasePath}/delete`, {
+      method: "DELETE",
+    });
     this.setTokenState(buildTokenState(undefined));
   }
 


### PR DESCRIPTION
`deleteUser()` defaults to GET, but the server only accepts DELETE — every call fails with `405 Method Not Allowed`.

**Root cause** (`crates/assets/js/client/src/client.ts`):

```ts
await this.fetch(`${authApiBasePath}/delete`); // no method = GET
```

The server route (`crates/core/src/auth/mod.rs:188`) is registered via axum's `delete(...)`, so GET is rejected with 405.

**Existing test** (`auth_test.rs:676`) didn't catch this because it calls `delete_handler` directly, bypassing the HTTP layer.

**Fix:**

```ts
await this.fetch(`${authApiBasePath}/delete`, { method: "DELETE" });
```

Affects any app using the SDK's `deleteUser()`, including the built-in auth-ui `Profile.tsx`.