### PR TITLE
feat(auth-ui): add profile API endpoint for per-user capabilities

### DIFF
--- a/crates/auth-ui/src/lib.rs
+++ b/crates/auth-ui/src/lib.rs
@@ -3,9 +3,10 @@
 #![warn(clippy::await_holding_lock, clippy::inefficient_to_string)]
 
 use askama::Template;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use trailbase_wasm::db;
 use trailbase_wasm::http::{
-  Html, HttpError, HttpRoute, IntoBody, IntoResponse, Redirect, Request, Response, StatusCode,
+  Html, HttpError, HttpRoute, IntoBody, IntoResponse, Json, Redirect, Request, Response, StatusCode,
   User, header, routing,
 };
 use trailbase_wasm::kv::Store;
@@ -98,6 +99,15 @@ impl Guest for Endpoints {
             .user()
             .ok_or_else(|| HttpError::status(StatusCode::UNAUTHORIZED))?;
           return ui_change_email_handler(req.query_parse()?, user).await;
+        },
+      ),
+      routing::get(
+        &format!("{AUTH_API}/profile"),
+        async |req: Request| -> Result<Response, HttpError> {
+          let user = req
+            .user()
+            .ok_or_else(|| HttpError::status(StatusCode::UNAUTHORIZED))?;
+          return profile_capabilities_handler(user).await;
         },
       ),
       routing::get("/_/auth/{*wildcard}", async |req: Request| {
@@ -397,7 +407,6 @@ async fn ui_change_email_handler(
 }
 
 async fn static_assets_handler(path: &str) -> Result<Response, HttpError> {
-  // We want as little magic as possible. The only /_/auth/subpath that isn't SSR, is
   // profile, so we when hitting /profile or /profile, we want actually want to serve
   // the static profile/index.html.
   let file = match path {
@@ -420,6 +429,54 @@ async fn static_assets_handler(path: &str) -> Result<Response, HttpError> {
 #[allow(unused)]
 fn internal(err: impl std::string::ToString) -> HttpError {
   return HttpError::message(StatusCode::INTERNAL_SERVER_ERROR, err);
+}
+
+#[derive(Serialize)]
+struct ProfileResponse {
+  show_otp_section: bool,
+  show_change_password: bool,
+}
+
+async fn profile_capabilities_handler(user: &User) -> Result<Response, HttpError> {
+  let rows = db::query(
+    r#"SELECT provider_id, password_hash FROM "_user" WHERE email = ?"#,
+    vec![db::Value::Text(user.email.clone())],
+  )
+  .await
+  .map_err(internal)?;
+
+  let is_oauth_only = rows
+    .first()
+    .and_then(|row| {
+      let is_oauth = match row.first()? {
+        db::Value::Integer(n) => *n != 0,
+        _ => false,
+      };
+      let no_password = match row.get(1)? {
+        db::Value::Text(s) => s.is_empty(),
+        _ => true,
+      };
+      Some(is_oauth && no_password)
+    })
+    .unwrap_or(false);
+
+  let password_auth_enabled = {
+    let store = Store::open().map_err(internal)?;
+    match store.get("config:auth").map_err(internal)? {
+      Some(bytes) if !bytes.is_empty() => serde_json::from_slice::<auth::AuthConfig>(&bytes)
+        .map(|c| !c.disable_password_auth)
+        .unwrap_or(true),
+      _ => true,
+    }
+  };
+
+  return Ok(
+    Json(ProfileResponse {
+      show_otp_section: !is_oauth_only && password_auth_enabled,
+      show_change_password: !is_oauth_only && password_auth_enabled,
+    })
+    .into_response(),
+  );
 }
 
 const AUTH_API: &str = "/api/auth/v1";

--- a/crates/auth-ui/ui/src/components/Profile.tsx
+++ b/crates/auth-ui/ui/src/components/Profile.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Switch, Show, Match } from "solid-js";
+import { createSignal, createResource, Switch, Show, Match } from "solid-js";
 import type { Signal } from "solid-js";
 import {
   TbFillUser,
@@ -175,6 +175,23 @@ function ProfileTable(props: { client: Client; user: User }) {
   const alert = () => new URL(location.href).searchParams.get("alert");
   const [deleteAccountOpen, setDeleteAccountOpen] = createSignal(false);
 
+  const [profileData] = createResource(
+    () => props.user,
+    async () => {
+      try {
+        const resp = await fetch("/api/auth/v1/profile", {
+          credentials: "include",
+        });
+        if (!resp.ok) return null;
+        return (await resp.json()) as { show_otp_section: boolean; show_change_password: boolean };
+      } catch {
+        return null;
+      }
+    },
+  );
+  const showOtpSection = () => profileData()?.show_otp_section ?? false;
+  const showChangePassword = () => profileData()?.show_change_password ?? false;
+
   return (
     <>
       <Card class="w-[80dvw] max-w-[540px] p-8">
@@ -188,13 +205,15 @@ function ProfileTable(props: { client: Client; user: User }) {
               </DropdownMenuTrigger>
 
               <DropdownMenuContent>
-                <a href="/_/auth/change_email">
-                  <DropdownMenuItem>Change Email</DropdownMenuItem>
-                </a>
+                 <a href="/_/auth/change_email">
+                   <DropdownMenuItem>Change Email</DropdownMenuItem>
+                 </a>
 
-                <a href="/_/auth/change_password">
-                  <DropdownMenuItem>Change Password</DropdownMenuItem>
-                </a>
+                 <Show when={showChangePassword()}>
+                   <a href="/_/auth/change_password">
+                     <DropdownMenuItem>Change Password</DropdownMenuItem>
+                   </a>
+                 </Show>
 
                 <DropdownMenuSeparator />
 
@@ -240,7 +259,9 @@ function ProfileTable(props: { client: Client; user: User }) {
         </div>
 
         <div class="my-4 flex w-full flex-col items-end gap-2">
-          <TotpToggleButton {...props} />
+          <Show when={showOtpSection()}>
+            <TotpToggleButton {...props} />
+          </Show>
         </div>
       </Card>
 


### PR DESCRIPTION
**Description:**

Adds a new `GET /api/auth/v1/profile` endpoint to the auth-ui WASM component that returns server-side capability flags for the currently authenticated user.

**Why:** The profile page unconditionally shows the TOTP setup/disable button and the "Change Password" link — including for users who signed in via an external OAuth/OIDC provider. OAuth users have no password, so both options are misleading and non-functional for them.

**What changed:**
- New `GET /api/auth/v1/profile` route in `auth-ui` WASM. Requires authentication (401 if not logged in). Queries `provider_id` and `password_hash` from the `_user` table and reads `config:auth` from the KV store to compute two capability flags. A user is considered OAuth-only when `provider_id != 0` and `password_hash` is empty; users with an admin-assigned password are treated as password-capable regardless of `provider_id`.
- `Profile.tsx` uses `createResource` to fetch this endpoint, wraps `<TotpToggleButton>` in `<Show when={showOtpSection()}>`, and wraps the "Change Password" link in `<Show when={showChangePassword()}>`.

**Response shape:**
```json
{ "show_otp_section": true, "show_change_password": false }
```

Both flags encode the full server-side decision, so clients don't need to reason about `provider_id`, `password_hash`, or config fields separately.