### PR TITLE
Fix spurious scrollbar on accounts page

### DIFF
--- a/crates/assets/js/admin/src/App.tsx
+++ b/crates/assets/js/admin/src/App.tsx
@@ -40,7 +40,7 @@ function TopNav(props: RouteSectionProps) {
     <>
       <HorizontalNavbar height={48} location={props.location} />
 
-      <main class="max-h-[calc(100vh-48px)] w-screen">
+      <main class="max-h-[calc(100vh-48px)] w-screen overflow-y-auto">
         <ErrorBoundary>{props.children}</ErrorBoundary>
       </main>
     </>

--- a/crates/assets/js/admin/src/components/accounts/AccountsPage.tsx
+++ b/crates/assets/js/admin/src/components/accounts/AccountsPage.tsx
@@ -414,7 +414,7 @@ export function AccountsPage() {
   });
 
   return (
-    <div class="h-full">
+    <div>
       <Header
         title="Accounts"
         left={


### PR DESCRIPTION
Removed h-full from the AccountsPage root div to prevent sub-pixel height overflow from producing a spurious scrollbar Added overflow-y-auto to the TopNav main element so tall content scrolls inside the panel instead of the document body

AccountsPage produced a scrollbar even when content was shorter than the viewport due to h-dvh vs 100% sub-pixel rounding in the browser