### PR TITLE
Update custom-binary example to trigger migrations

### DIFF
--- a/examples/custom-binary/src/main.rs
+++ b/examples/custom-binary/src/main.rs
@@ -45,12 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     .install_default()
     .expect("Failed to install rustls crypto");
 
-  let Server {
-    state,
-    main_router,
-    admin_router,
-    tls,
-  } = Server::init_with_custom_initializer(
+  let server = Server::init_with_custom_initializer(
     ServerOptions {
       data_dir: DataDir::default(),
       address: "localhost:4004".to_string(),
@@ -72,16 +67,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let custom_router = Router::new()
       .route("/", get(hello_world_handler))
       .with_state(CustomState {
-        state,
+        state: server.state.clone(),
         greeting: Some("Hi".to_string()),
       })
-      .merge(main_router.1);
+      .merge(server.main_router.1);
 
-    (main_router.0, custom_router)
+    (server.main_router.0, custom_router)
   };
 
-  let (cleanup_sender, _cleanup_receiver) = tokio::sync::oneshot::channel::<()>();
-  trailbase::api::serve(router, admin_router, tls, cleanup_sender).await?;
+  let server = Server {
+    main_router: router,
+    ..server
+  };
+  server.serve().await?;
 
   Ok(())
 }


### PR DESCRIPTION
The `example/custom-binary` uses the `trailbase::api::serve` function,
which starts the services but don't trigger the boostrap user migrations
itself.

Reverse enginering how the `cli::run` command works, it seems it's
triggered by `Server::serve` function instead.

This commit updates the example code to use the `Server:serve` function
to ensure initial migration logic is included on the custom binary.

---

Note: the current example fails in `debug` mode, as it attempts to access
`User` from the `trailbase` extractor, but there is an `assert!` informing that
the `CookieManage` layer is not installed.

It should be possible to fix it by adding the `CookieManage` layer as well on
the custom router, but maybe a better fix would be to pass in an
`custom_router` on `ServerOptions` to be merged and use the same shared layers.
