### PR TITLE
fix: bundle TypeScript types as expected

### DIFF
--- a/crates/assets/js/client/package.json
+++ b/crates/assets/js/client/package.json
@@ -30,7 +30,7 @@
     "build": "vite build",
     "check": "tsc --noEmit --skipLibCheck && eslint",
     "format": "prettier -w src tests",
-    "prepack": "rm -rf ./dist && pnpm build && test -e ./dist/index.js",
+    "prepack": "rm -rf ./dist && pnpm build && test -e ./dist/index.js && test -e ./dist/index.d.ts",
     "test": "vitest run && vite-node tests/integration_test_runner.ts"
   },
   "dependencies": {
@@ -42,6 +42,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@microsoft/api-extractor": "^7.58.9",
+    "ajv": "^8.20.0",
     "eslint": "^10.4.1",
     "globals": "^17.6.0",
     "http-status": "^2.1.0",

--- a/crates/assets/js/client/vite.config.ts
+++ b/crates/assets/js/client/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
       // copyDtsFiles: true,
       // staticImport: true,
       // insertTypesEntry: true,
-      rollupTypes: true,
+      bundleTypes: true,
     }),
   ],
 })


### PR DESCRIPTION
The project is using `vite-plugin-dts` to prepare the JS/TS library for
publishing functions with type annotations. The `package.json` expects a
`index.d.ts` file to exist to offer types to clients.

The upgrade to `vite-plugin-dts` to v5 had a breaking change on the API,
which now requires `@microsoft/api-extractor` to produce a unified
`index.d.ts` instead of a separate `src/*.d.ts`. To run this library,
`ajv` was also required as an optional peer package (at least on Bun).

The breaking change on the `vite-plugin-dts` also had some config field
name changes which has adjusted.

To avoid regressions, `npm run prepack` will check for the `index.d.ts`
file in case there are future breaking changes.

Without this file, downstream clients cannot find types:

```text
error: Lint or type issues found
× typescript(TS7016): Could not find a declaration file for module 'trailbase'. 'F:/repos/vintage/node_modules/trailbase/dist/index.js' implicitly has an 'any' type.
   ╭─[src/routes/product/[id]/+page.ts:2:29]
 2 │ import { type Client } from "trailbase";
 ```
