### PR TITLE
Fix theme toggle icon showing wrong state on initial load

### DIFF
--- a/crates/assets/js/admin/src/lib/theme.ts
+++ b/crates/assets/js/admin/src/lib/theme.ts
@@ -38,9 +38,14 @@ export function createTheme(): Accessor<ResolvedTheme> {
     });
   });
 
-  onMount(() =>
-    attrObserver.observe(document.documentElement, { attributes: true }),
-  );
+  onMount(() => {
+    // `initializeTheme()` (called from a parent's onMount) may already have
+    // applied the resolved theme by the time we get here, i.e. before the
+    // observer below starts watching, so the initial signal snapshot above
+    // can be stale. Re-sync once on mount to close that race.
+    setTheme(currentTheme());
+    attrObserver.observe(document.documentElement, { attributes: true });
+  });
   onCleanup(() => attrObserver.disconnect());
 
   return theme;


### PR DESCRIPTION
`createTheme()` seeds its signal from `currentTheme()` before `initializeTheme()` applies the resolved theme to `<html>`. The signal is meant to resync via a `MutationObserver`, but that observer attaches in `createTheme()`'s own `onMount`, which fires *after* the parent `App`'s `onMount` already toggled the `dark` class — so the observer misses the mutation and the icon stays stuck on the stale initial state (moon shown on dark startup).

**Fix:** force `setTheme(currentTheme())` right before attaching the observer, resyncing to actual DOM state at mount time regardless of onMount order.

**Testing:** verified manually with dark preference on load — icon now correct immediately; toggling still works.