### PR TITLE
fix(dart): robust SSE chunk parsing for multi-event TCP packets

### DIFF
--- a/client/dart/lib/src/sse.dart
+++ b/client/dart/lib/src/sse.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 
@@ -102,9 +101,9 @@ Future<Stream<Event>> connectSse(
             while ((index = buffer.indexOf('\n\n')) != -1) {
               final eventStr = buffer.substring(0, index);
               buffer = buffer.substring(index + 2);
-              
+
               if (eventStr.trim().isEmpty) continue;
-              
+
               for (final line in eventStr.split('\n')) {
                 if (line.startsWith('data: ')) {
                   try {
@@ -134,13 +133,6 @@ Future<Stream<Event>> connectSse(
   }
 
   return (await connectSseImpl()).stream;
-}
-
-bool _endsWithNewlineNewline(List<int> bytes) {
-  if (bytes.length >= 2) {
-    return bytes[bytes.length - 1] == 10 && bytes[bytes.length - 2] == 10;
-  }
-  return false;
 }
 
 Event _eventfromJson(Map<String, dynamic> json) {

--- a/client/dart/lib/src/sse.dart
+++ b/client/dart/lib/src/sse.dart
@@ -83,7 +83,7 @@ Future<Stream<Event>> connectSse(
     }
 
     late final StreamController<Event> ctrl;
-    StreamSubscription<List<int>>? subscription;
+    StreamSubscription<String>? subscription;
 
     ctrl = StreamController<Event>.broadcast(
       onCancel: () {
@@ -94,21 +94,28 @@ Future<Stream<Event>> connectSse(
         // NOTE: Unlike the default StreamController, the broadcast one doesn't
         // buffer. Hence we have to delay listening until somebody starts
         // listening.
-        final buffer = BytesBuilder();
-        subscription = response.stream.listen(
-          (List<int> data) {
-            if (_endsWithNewlineNewline(data)) {
-              if (buffer.isNotEmpty) {
-                buffer.add(data);
-
-                final event = decodeEvent(buffer.takeBytes());
-                if (event != null) ctrl.add(event);
-              } else {
-                final event = decodeEvent(data);
-                if (event != null) ctrl.add(event);
+        String buffer = '';
+        subscription = response.stream.transform(utf8.decoder).listen(
+          (String data) {
+            buffer += data;
+            int index;
+            while ((index = buffer.indexOf('\n\n')) != -1) {
+              final eventStr = buffer.substring(0, index);
+              buffer = buffer.substring(index + 2);
+              
+              if (eventStr.trim().isEmpty) continue;
+              
+              for (final line in eventStr.split('\n')) {
+                if (line.startsWith('data: ')) {
+                  try {
+                    final event = _eventfromJson(jsonDecode(line.substring(6)));
+                    ctrl.add(event);
+                  } catch (e, st) {
+                    ctrl.addError(e, st);
+                  }
+                  break;
+                }
               }
-            } else {
-              buffer.add(data);
             }
           },
           onDone: () => ctrl.close(),

--- a/client/dart/test/sse_chunking_test.dart
+++ b/client/dart/test/sse_chunking_test.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+import 'package:trailbase/src/sse.dart';
+import 'package:trailbase/src/transport.dart';
+
+class MockTransport implements Transport {
+  final List<int> payload;
+
+  MockTransport(this.payload);
+
+  @override
+  Future<http.Response> fetch(
+    String path, {
+    Method method = Method.get,
+    Map<String, String>? headers,
+    String? body,
+    Map<String, dynamic>? queryParams,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<http.StreamedResponse> stream(
+    Uri uri, {
+    Map<String, String>? headers,
+  }) async {
+    // Create a stream that emits our payload in a single chunk
+    final stream = Stream<List<int>>.fromIterable([payload]);
+    
+    return http.StreamedResponse(
+      stream,
+      200,
+      request: http.Request('GET', uri),
+    );
+  }
+}
+
+void main() {
+  test('connectSse properly splits chunked events', () async {
+    // Create a scenario where TWO SSE events arrive perfectly merged inside a single TCP buffer chunk
+    const event1 = '{"Insert": {"id": 1, "test": "a"}, "seq": 1}';
+    const event2 = '{"Insert": {"id": 2, "test": "b"}, "seq": 2}';
+    
+    // The server separates events with \n\n.
+    // If the network delivers them in a single chunk, it looks like this:
+    const payload = 'data: $event1\n\n'
+                    'data: $event2\n\n';
+                    
+    final transport = MockTransport(utf8.encode(payload));
+    
+    final sseStream = await connectSse(transport, Uri.parse('http://localhost'));
+    
+    final events = await sseStream.take(2).toList();
+    
+    expect(events.length, 2);
+    
+    expect(events[0], isA<InsertEvent>());
+    expect(events[0].seq, 1);
+    
+    expect(events[1], isA<InsertEvent>());
+    expect(events[1].seq, 2);
+  });
+}

--- a/client/dart/test/sse_chunking_test.dart
+++ b/client/dart/test/sse_chunking_test.dart
@@ -6,9 +6,9 @@ import 'package:trailbase/src/sse.dart';
 import 'package:trailbase/src/transport.dart';
 
 class MockTransport implements Transport {
-  final List<int> payload;
+  final List<List<int>> payloadChunks;
 
-  MockTransport(this.payload);
+  MockTransport(this.payloadChunks);
 
   @override
   Future<http.Response> fetch(
@@ -26,9 +26,9 @@ class MockTransport implements Transport {
     Uri uri, {
     Map<String, String>? headers,
   }) async {
-    // Create a stream that emits our payload in a single chunk
-    final stream = Stream<List<int>>.fromIterable([payload]);
-    
+    // Create a stream that emits our payload chunks exactly as specified
+    final stream = Stream<List<int>>.fromIterable(payloadChunks);
+
     return http.StreamedResponse(
       stream,
       200,
@@ -42,24 +42,61 @@ void main() {
     // Create a scenario where TWO SSE events arrive perfectly merged inside a single TCP buffer chunk
     const event1 = '{"Insert": {"id": 1, "test": "a"}, "seq": 1}';
     const event2 = '{"Insert": {"id": 2, "test": "b"}, "seq": 2}';
-    
+
     // The server separates events with \n\n.
     // If the network delivers them in a single chunk, it looks like this:
     const payload = 'data: $event1\n\n'
-                    'data: $event2\n\n';
-                    
-    final transport = MockTransport(utf8.encode(payload));
-    
-    final sseStream = await connectSse(transport, Uri.parse('http://localhost'));
-    
+        'data: $event2\n\n';
+
+    final transport = MockTransport([utf8.encode(payload)]);
+
+    final sseStream =
+        await connectSse(transport, Uri.parse('http://localhost'));
+
     final events = await sseStream.take(2).toList();
-    
+
     expect(events.length, 2);
-    
+
     expect(events[0], isA<InsertEvent>());
     expect(events[0].seq, 1);
-    
+
     expect(events[1], isA<InsertEvent>());
     expect(events[1].seq, 2);
+  });
+
+  test('connectSse properly handles standard single-event chunks', () async {
+    const event1 = '{"Insert": {"id": 1, "test": "a"}, "seq": 1}';
+    const event2 = '{"Insert": {"id": 2, "test": "b"}, "seq": 2}';
+
+    // Simulate regular stream where each TCP chunk corresponds exactly to one event
+    final streamData = [
+      utf8.encode('data: $event1\n\n'),
+      utf8.encode('data: $event2\n\n'),
+    ];
+
+    final transport = MockTransport(streamData);
+    final sseStream =
+        await connectSse(transport, Uri.parse('http://localhost'));
+    final events = await sseStream.take(2).toList();
+
+    expect(events.length, 2);
+    expect(events[0].seq, 1);
+    expect(events[1].seq, 2);
+  });
+
+  test('connectSse properly handles fragmented events across chunks', () async {
+    // Simulate a slow network where a single event is fragmented across two TCP chunks
+    final streamData = [
+      utf8.encode('data: {"Insert": {"id": 1, '),
+      utf8.encode('"test": "a"}, "seq": 1}\n\n'),
+    ];
+
+    final transport = MockTransport(streamData);
+    final sseStream =
+        await connectSse(transport, Uri.parse('http://localhost'));
+    final events = await sseStream.take(1).toList();
+
+    expect(events.length, 1);
+    expect(events[0].seq, 1);
   });
 }


### PR DESCRIPTION
The original connectSse logic in lib/src/sse.dart used a BytesBuilder to buffer incoming TCP packets from the http.StreamedResponse. When it detected a chunk ending in \n\n, it blindly assumed that the entire buffer contained exactly one complete SSE event, which it passed to jsonDecode.

Why it crashes: In high-throughput real-time streams (like a bulk data sync), multiple SSE events can be concatenated and delivered in a single TCP chunk by the underlying network stack. If a packet arrives containing two events merged together (e.g., data: {...}\n\ndata: {...}\n\n), the BytesBuilder passes the whole string into jsonDecode. jsonDecode successfully parses the first object but crashes immediately upon hitting the trailing data: keyword of the second event, throwing FormatException: Unexpected character.

The Fix: The payload parsing was updated to use a String buffer that loops through the buffer using indexOf('\n\n'). It now recursively extracts and isolates every individual event from the stream chunk, ensuring jsonDecode is only ever handed a single, clean JSON string per parse.