### PR TITLE
fix: Silent Refresh Auth Bug 

### DIFF
--- a/crates/core/src/auth/auth_test.rs
+++ b/crates/core/src/auth/auth_test.rs
@@ -1422,6 +1422,77 @@ async fn test_auth_annonymous_signin() {
   .unwrap();
 }
 
+#[tokio::test]
+async fn test_auth_refresh_after_anonymous_promotion() {
+  let mailer = TestAsyncSmtpTransport::new();
+  let state = test_state(Some(TestStateOptions {
+    mailer: Some(Mailer::Smtp(Arc::new(mailer.clone()))),
+    config: Some({
+      let mut config = build_test_config_with_trivial_tokens();
+      config.auth.user_identifier = Some(UserIdentifier::RequireEmail.into());
+      config.auth.enable_anonymous_signin = Some(true);
+      config
+    }),
+    ..Default::default()
+  }))
+  .await
+  .unwrap();
+
+  let response = login_anonymous_user_handler(
+    State(state.clone()),
+    Query(Default::default()),
+    Cookies::default(),
+    Either::Json(LoginAnonymousRequest {
+      params: Default::default(),
+    }),
+  )
+  .await
+  .unwrap();
+
+  let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+    .await
+    .unwrap();
+  let login_response: LoginResponse = serde_json::from_slice(&body).unwrap();
+  let user = User::from_auth_token(&state, &login_response.auth_token).unwrap();
+
+  // Anonymous users are unverified but have no email, so refreshing has to keep working for them.
+  let Json(_refreshed_tokens) = refresh_handler(
+    State(state.clone()),
+    Json(RefreshRequest {
+      refresh_token: login_response.refresh_token.clone(),
+    }),
+  )
+  .await
+  .unwrap();
+
+  promote_anonymous_user_handler(
+    State(state.clone()),
+    Query(Default::default()),
+    user.clone(),
+    Either::Json(PromoteAnonymousRequest {
+      new_password: "secret123".to_string(),
+      new_email: Some("user@test.org".to_string()),
+      ..Default::default()
+    }),
+  )
+  .await
+  .unwrap();
+
+  // Promotion attaches a not-yet-verified email to the pre-existing session. Since tokens must
+  // never be minted for a user with an unverified email, refreshing that session has to fail
+  // rather than hand out fresh tokens.
+  assert!(matches!(
+    refresh_handler(
+      State(state.clone()),
+      Json(RefreshRequest {
+        refresh_token: login_response.refresh_token,
+      }),
+    )
+    .await,
+    Err(AuthError::Unauthorized)
+  ));
+}
+
 async fn session_exists(state: &AppState, user_id: Uuid) -> bool {
   return state
     .session_conn()

--- a/crates/core/src/auth/auth_test.rs
+++ b/crates/core/src/auth/auth_test.rs
@@ -1485,12 +1485,30 @@ async fn test_auth_refresh_after_anonymous_promotion() {
     refresh_handler(
       State(state.clone()),
       Json(RefreshRequest {
-        refresh_token: login_response.refresh_token,
+        refresh_token: login_response.refresh_token.clone(),
       }),
     )
     .await,
     Err(AuthError::Unauthorized)
   ));
+
+  state
+    .user_conn()
+    .execute_batch(format!(
+      "UPDATE {USER_TABLE} SET verified = TRUE WHERE email = 'user@test.org';"
+    ))
+    .await
+    .unwrap();
+
+  // Verifying doesn't revoke the session, it merely paused it. Refreshing works again.
+  let Json(_refreshed_tokens) = refresh_handler(
+    State(state.clone()),
+    Json(RefreshRequest {
+      refresh_token: login_response.refresh_token,
+    }),
+  )
+  .await
+  .unwrap();
 }
 
 async fn session_exists(state: &AppState, user_id: Uuid) -> bool {

--- a/crates/core/src/auth/tokens.rs
+++ b/crates/core/src/auth/tokens.rs
@@ -231,20 +231,24 @@ pub(crate) async fn reauth_with_refresh_token(
     return Err(AuthError::Unauthorized);
   };
 
-  const USER_QUERY: &str = formatcp!(r#"SELECT * FROM "{USER_TABLE}" WHERE id = $1"#);
+  // NOTE: The `verified` condition mirrors `mint_new_tokens`: a user with an email must have it
+  // verified before we hand out tokens. Anonymous users are exempt, since they have no email.
+  const USER_QUERY: &str =
+    formatcp!(r#"SELECT * FROM "{USER_TABLE}" WHERE id = $1 AND (email IS NULL OR verified)"#);
 
   let Some(db_user) = state
     .user_conn()
     .read_query_value::<DbUser>(USER_QUERY, params!(user_id))
     .await?
   else {
-    // Row not found case, typically expected in one of 4 cases:
+    // Row not found case, typically expected in one of 5 cases:
     //  1. Above where clause doesn't match, e.g. refresh token expired.
     //  2. Token was actively deleted and thus revoked.
     //  3. User explicitly logged out, which will delete **all** sessions for that user.
     //  4. Database was overwritten, e.g. by tests or periodic reset for the demo.
+    //  5. User's email is not verified (yet), e.g. right after promoting an anonymous user.
     #[cfg(debug_assertions)]
-    log::debug!("User not found");
+    log::debug!("User not found or unverified");
 
     return Err(AuthError::Unauthorized);
   };


### PR DESCRIPTION
Promoting an anonymous user (before this change) would crash via debug_assert locally, and silently mint auth tokens for a user with an unverified email address in prod.

Here's the old version, which doesn't successfully filter our unverified (promoted anonymous) users.

```rust
  const USER_QUERY: &str = formatcp!(r#"SELECT * FROM "{USER_TABLE}" WHERE id = $1"#);

  let Some(db_user) = state
    .user_conn()
    .read_query_value::<DbUser>(USER_QUERY, params!(user_id))
    .await?
  else {
    // Row not found case, typically expected in one of 4 cases:
    //  1. Above where clause doesn't match, e.g. refresh token expired.
    //  2. Token was actively deleted and thus revoked.
    //  3. User explicitly logged out, which will delete **all** sessions for that user.
    //  4. Database was overwritten, e.g. by tests or periodic reset for the demo.
    #[cfg(debug_assertions)]
    log::debug!("User not found");

    return Err(AuthError::Unauthorized);
  };

  debug_assert!(
    db_user.email.is_none() || db_user.verified,
    "unverified user, should have been caught by above query"
  );
```

I think I also spotted the root cause in git archaeology. The assert's message "should have been caught by above query" was literally true once. Before commit 719e4eb2 ("Move session data into a separate DB"), this was a single joined query ending in AND user.verified, so the assert was guaranteed. That commit split it into a session lookup plus a user lookup and dropped the verified condition from the WHERE clause, but left the assert behind. Later, aca14408 ("Add anonymous login to Swift client") hit the resulting failure for anonymous users, who are legitimately unverified, and relaxed it from assert!(db_user.verified) to debug_assert!(db_user.email.is_none() || db_user.verified). That silenced the symptom for anonymous users and stopped checking in release builds, but never restored the query filter.

Now here's the new version I came up with:

```rust
  // NOTE: The `verified` condition mirrors `mint_new_tokens`: a user with an email must have it
  // verified before we hand out tokens. Anonymous users are exempt, since they have no email.
  const USER_QUERY: &str =
    formatcp!(r#"SELECT * FROM "{USER_TABLE}" WHERE id = $1 AND (email IS NULL OR verified)"#);

  let Some(db_user) = state
    .user_conn()
    .read_query_value::<DbUser>(USER_QUERY, params!(user_id))
    .await?
  else {
    // Row not found case, typically expected in one of 5 cases:
    //  1. Above where clause doesn't match, e.g. refresh token expired.
    //  2. Token was actively deleted and thus revoked.
    //  3. User explicitly logged out, which will delete **all** sessions for that user.
    //  4. Database was overwritten, e.g. by tests or periodic reset for the demo.
    //  5. User's email is not verified (yet), e.g. right after promoting an anonymous user.
    #[cfg(debug_assertions)]
    log::debug!("User not found or unverified");

    return Err(AuthError::Unauthorized);
  };

  debug_assert!(
    db_user.email.is_none() || db_user.verified,
    "unverified user, should have been caught by above query"
  );
```

This is the right fix since it makes refresh accept precisely the set of users for whom a session could be created in the first place (via `mint_new_tokens`).

The alternative design would be to let a promoted user keep their session, on the grounds that they were already authenticated as that account and only new logins should be gated on verification. That's defensible, but it would mean relaxing mint_new_tokens too, and it leaves an unverified address attached to a live session.

