### PR TITLE
Fix Apple OAuth: form POST callback, id_token parsing, request-body auth, SameSite=None (#282)

### DIFF
--- a/crates/core/src/auth/oauth/callback.rs
+++ b/crates/core/src/auth/oauth/callback.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Extension, Json, Path, Query, State};
+use axum::extract::{Extension, Form, Path, Query, State};
 use axum::http::{self, HeaderName, HeaderValue, StatusCode};
 use axum::response::{AppendHeaders, IntoResponse, Redirect, Response};
 use chrono::Utc;
@@ -29,7 +29,9 @@ use crate::rand::random_alphanumeric;
 
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]
 pub struct CallbackQuery {
-  pub code: String,
+  /// Authorization code. Absent when the provider reports an `error` instead, e.g. when
+  /// the user cancelled the consent dialog (Apple sends `error` + `state` without `code`).
+  pub code: Option<String>,
   pub state: String,
   pub error: Option<String>,
 }
@@ -60,7 +62,7 @@ pub(crate) async fn callback_from_external_auth_provider_get(
   post,
   path = "/oauth/{provider}/callback",
   tag = "auth",
-  request_body = CallbackQuery,
+  request_body(content = CallbackQuery, content_type = "application/x-www-form-urlencoded"),
   responses(
     (status = 200, description = "Redirect.")
   )
@@ -70,7 +72,7 @@ pub(crate) async fn callback_from_external_auth_provider_post(
   Path(provider): Path<String>,
   Extension(HasRoot(has_root)): Extension<HasRoot>,
   cookies: Cookies,
-  request: Json<CallbackQuery>,
+  request: Form<CallbackQuery>,
 ) -> Result<Response, AuthError> {
   return callback_from_external_auth_provider_impl(
     &state, provider, request.0, has_root, &cookies,
@@ -88,6 +90,10 @@ async fn callback_from_external_auth_provider_impl(
   if let Some(err) = query.error {
     return Err(AuthError::FailedDependency(err.into()));
   }
+
+  let Some(auth_code) = query.code else {
+    return Err(AuthError::BadRequest("missing code"));
+  };
 
   let auth_options = state.auth_options();
   let Some(oauth_entry) = auth_options.lookup_oauth_provider(&provider) else {
@@ -130,7 +136,7 @@ async fn callback_from_external_auth_provider_impl(
         cookies,
         oauth_entry,
         redirect_uri,
-        query.code,
+        auth_code,
         pkce_code_verifier,
         user_pkce_code_challenge,
       )
@@ -142,7 +148,7 @@ async fn callback_from_external_auth_provider_impl(
         cookies,
         oauth_entry,
         redirect_uri,
-        query.code,
+        auth_code,
         pkce_code_verifier,
         has_root,
       )
@@ -311,6 +317,15 @@ async fn get_or_create_user(
     .set_pkce_verifier(PkceCodeVerifier::new(server_pkce_code_verifier))
     .request_async(&ReqwestClient(&http_client))
     .await
+    .map_err(|err| {
+      // Not all providers respond with RFC-6749-compliant error bodies, so log the raw
+      // error for diagnostics before possibly falling back to the provider's custom parser.
+      log::warn!(
+        "OAuth token exchange with '{name}' failed: {err}",
+        name = provider.name()
+      );
+      return err;
+    })
     .or_else(|err| match err {
       oauth2::RequestTokenError::Parse(path, resp) => provider.parse_token_response(&path, &resp),
       err => Err(AuthError::FailedDependency(err.into())),

--- a/crates/core/src/auth/oauth/login.rs
+++ b/crates/core/src/auth/oauth/login.rs
@@ -3,13 +3,14 @@ use axum::response::Redirect;
 use chrono::Duration;
 use oauth2::{CsrfToken, PkceCodeChallenge, Scope};
 use tower_cookies::Cookies;
+use tower_cookies::cookie::SameSite;
 
 use crate::AppState;
 use crate::auth::AuthError;
 use crate::auth::login_params::{LoginInputParams, LoginParams, build_and_validate_input_params};
 use crate::auth::oauth::state::{OAuthStateClaims, ResponseType};
 use crate::auth::options::OAuthEntry;
-use crate::auth::util::new_cookie;
+use crate::auth::util::{new_cookie_same_site, secure_tls_only};
 use crate::config::proto;
 use crate::constants::COOKIE_OAUTH_STATE;
 
@@ -39,6 +40,11 @@ pub(crate) async fn login_with_external_auth_provider(
     client: oauth_client,
     ..
   } = oauth_entry;
+
+  // Some providers, e.g. Apple, respond to the authorization request with an auto-submitting
+  // form POSTing the response to our callback (`response_mode=form_post`) rather than
+  // redirecting with query parameters.
+  let form_post_response_mode = provider.uses_form_post_response_mode();
 
   let login_params = build_and_validate_input_params(&state, login_input_query)?;
   let user_identifier = state
@@ -86,20 +92,37 @@ pub(crate) async fn login_with_external_auth_provider(
     },
   };
 
-  cookies.add(new_cookie(
+  // NOTE: we need cookie to be included when redirected back from oauth provider, thus
+  // `same_site` can at most be `Lax`. For providers responding with `form_post`, the
+  // response is a cross-site POST navigation and `SameSite=Lax` cookies are not attached
+  // to those, so we have to fall back to `SameSite=None` (which browsers only honor
+  // together with `Secure`, i.e. HTTPS).
+  let state_cookie_same_site = if form_post_response_mode {
+    SameSite::None
+  } else {
+    SameSite::Lax
+  };
+
+  if form_post_response_mode && !secure_tls_only(&state) {
+    log::warn!(
+      "OAuth provider '{}' responds with `response_mode=form_post`, but the site \
+       isn't served over HTTPS: browsers drop `SameSite=None` cookies without the `Secure` \
+       attribute and the OAuth flow will fail at the callback",
+      provider.name()
+    );
+  }
+
+  cookies.add(new_cookie_same_site(
     &state,
     COOKIE_OAUTH_STATE,
     // Encoding as JWT token for tamper proofing. This doesn't encrypt anything but merely adds a
     // signature. None of the state handed to the user needs to be hidden from the user.
-    //
-    // NOTE: we need cookie to be included when redirected back from oauth provider, thus
-    // `same_site_strict = false`.
     state
       .jwt()
       .encode(&oauth_state)
       .map_err(|err| AuthError::Internal(err.into()))?,
     Duration::minutes(5),
-    /* same_site_strict= */ false,
+    state_cookie_same_site,
   ));
 
   Ok(Redirect::to(authorize_url.as_str()))

--- a/crates/core/src/auth/oauth/oauth_test.rs
+++ b/crates/core/src/auth/oauth/oauth_test.rs
@@ -7,11 +7,12 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::HashMap;
-use tower_cookies::Cookies;
+use tower_cookies::{CookieManagerLayer, Cookies, cookie::SameSite};
 use uuid::Uuid;
 
 use crate::api::AuthTokenClaims;
 use crate::app_state::{AppState, TestStateOptions, test_state};
+use crate::auth::AuthError;
 use crate::auth::api::token::{
   AuthCodeToTokenRequest, TokenResponse as TokenHandlerResponse, auth_code_to_token_handler,
 };
@@ -216,7 +217,7 @@ async fn test_oauth_login_flow_without_pkce() {
     cookies.clone(),
     Query(callback::CallbackQuery {
       state: auth_query.state.clone(),
-      code: auth_query.code_challenge.clone(),
+      code: Some(auth_query.code_challenge.clone()),
       error: None,
     }),
   )
@@ -326,7 +327,7 @@ async fn test_oauth_login_flow_with_pkce() {
     cookies.clone(),
     Query(callback::CallbackQuery {
       state: auth_query.state.clone(),
-      code: auth_query.code_challenge.clone(),
+      code: Some(auth_query.code_challenge.clone()),
 
       error: None,
     }),
@@ -388,6 +389,342 @@ async fn test_oauth_login_flow_with_pkce() {
   assert_eq!(
     EXTERNAL_USER_EMAIL,
     decoded_claims.email.as_deref().unwrap()
+  );
+}
+
+#[tokio::test]
+async fn test_apple_oauth_login_uses_form_post_response_mode() {
+  // Apple's provider uses hardcoded appleid.apple.com URLs and no network requests are made:
+  // we only inspect the generated redirect URL and the OAuth state cookie.
+  let site_url = "https://bar.org";
+  let state = test_state(Some(TestStateOptions {
+    config: Some({
+      let mut config = proto::Config::new_with_custom_defaults();
+      config.server.site_url = Some(site_url.to_string());
+      config.auth.oauth_providers = [(
+        "apple".to_string(),
+        proto::OAuthProviderConfig {
+          client_id: Some("test_client_id".to_string()),
+          client_secret: Some("test_client_secret".to_string()),
+          provider_id: Some(proto::OAuthProviderId::Apple as i32),
+          ..Default::default()
+        },
+      )]
+      .into();
+      config
+    }),
+    ..Default::default()
+  }))
+  .await
+  .unwrap();
+
+  // Call TB's OAuth login handler for Apple, which produces the redirect to Apple's
+  // authorization endpoint.
+  let cookies = Cookies::default();
+  let redirect_uri = format!("{site_url}/login-success-welcome");
+  let external_redirect: Redirect = login::login_with_external_auth_provider(
+    State(state.clone()),
+    Path("apple".to_string()),
+    Query(LoginInputParams {
+      redirect_uri: Some(redirect_uri),
+      mfa_redirect_uri: None,
+      response_type: None,
+      pkce_code_challenge: None,
+    }),
+    cookies.clone(),
+  )
+  .await
+  .unwrap();
+
+  let (location, _) = get_redirect_location(external_redirect);
+  let location = location.unwrap();
+
+  let authorize_url = url::Url::parse(&location).unwrap();
+  assert_eq!(authorize_url.host_str(), Some("appleid.apple.com"));
+  assert_eq!(authorize_url.path(), "/auth/authorize");
+
+  let query_params: HashMap<Cow<'_, str>, Cow<'_, str>> = authorize_url.query_pairs().collect();
+  // Apple rejects authorization requests requesting user-info scopes without
+  // `response_mode=form_post`.
+  assert_eq!(query_params.get("response_mode").unwrap(), "form_post");
+  assert_eq!(query_params.get("response_type").unwrap(), "code");
+  assert_eq!(query_params.get("scope").unwrap(), "name email");
+  assert_eq!(
+    query_params.get("redirect_uri").unwrap(),
+    format!("{site_url}/{AUTH_API_PATH}/oauth/apple/callback").as_str()
+  );
+
+  // The `state` sent to Apple must roundtrip the CSRF secret stored in the state cookie.
+  let oauth_state: OAuthStateClaims = state
+    .jwt()
+    .decode(cookies.get(COOKIE_OAUTH_STATE).unwrap().value())
+    .unwrap();
+  assert_eq!(
+    query_params.get("state").unwrap(),
+    oauth_state.csrf_secret.as_str()
+  );
+
+  // The OAuth state cookie has to be attached to Apple's cross-site form POST callback
+  // and thus requires SameSite=None.
+  assert_eq!(
+    cookies.get(COOKIE_OAUTH_STATE).unwrap().same_site(),
+    Some(SameSite::None)
+  );
+  assert_eq!(
+    cookies.get(COOKIE_OAUTH_STATE).unwrap().http_only(),
+    Some(true)
+  );
+}
+
+#[tokio::test]
+async fn test_oauth_login_flow_with_form_post_callback() {
+  let site_url = "https://bar.org";
+  let (_server, state) = setup_fake_oauth_server(site_url).await;
+
+  // Call TB's OAuth login handler, which will produce a redirect for users to get the external
+  // auth provider's login form.
+  let cookies = Cookies::default();
+  let redirect_uri = format!("{site_url}/login-success-welcome");
+  let external_redirect: Redirect = login::login_with_external_auth_provider(
+    State(state.clone()),
+    Path(TestOAuthProvider::NAME.to_string()),
+    Query(LoginInputParams {
+      redirect_uri: Some(redirect_uri.to_string()),
+      mfa_redirect_uri: None,
+      response_type: None,
+      pkce_code_challenge: None,
+    }),
+    cookies.clone(),
+  )
+  .await
+  .unwrap();
+
+  // Redirect-response providers, like this test provider, must not request form_post.
+  let (location, _) = get_redirect_location(external_redirect);
+  let authorize_url = url::Url::parse(&location.unwrap()).unwrap();
+  let query_params: HashMap<Cow<'_, str>, Cow<'_, str>> = authorize_url.query_pairs().collect();
+  assert!(!query_params.contains_key("response_mode"));
+  assert_eq!(
+    cookies.get(COOKIE_OAUTH_STATE).unwrap().same_site(),
+    Some(SameSite::Lax)
+  );
+
+  // Call the fake server's auth endpoint.
+  let auth_query: AuthQuery = reqwest::get(authorize_url.as_str())
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+  // Pretend to be the external provider responding with `response_mode=form_post`: POST the
+  // code/state as a form to TB's OAuth callback handler.
+  let internal_redirect = callback::callback_from_external_auth_provider_post(
+    State(state.clone()),
+    Path(TestOAuthProvider::NAME.to_string()),
+    Extension(HasRoot(false)),
+    cookies.clone(),
+    Form(callback::CallbackQuery {
+      state: auth_query.state.clone(),
+      code: Some(auth_query.code_challenge.clone()),
+      error: None,
+    }),
+  )
+  .await
+  .unwrap();
+
+  let (location, referrer_policy) = get_redirect_location(internal_redirect);
+  assert_eq!(location, Some(redirect_uri));
+  assert_eq!(referrer_policy.as_deref(), Some("no-referrer"));
+
+  // Check user exists and is logged in.
+  let db_user = state
+    .user_conn()
+    .read_query_value::<DbUser>(
+      format!("SELECT * FROM {USER_TABLE} WHERE provider_user_id = $1"),
+      (EXTERNAL_USER_ID,),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+  assert_eq!(EXTERNAL_USER_EMAIL, db_user.email.as_deref().unwrap());
+
+  // Is logged in.
+  assert!(session_exists(&state, db_user.uuid()).await);
+
+  // And we have tokens.
+  let auth_token = cookies.get(COOKIE_AUTH_TOKEN).unwrap().value().to_string();
+  let decoded_claims = state.jwt().decode::<AuthTokenClaims>(&auth_token).unwrap();
+  assert_eq!(db_user.email, decoded_claims.email);
+}
+
+#[tokio::test]
+async fn test_oauth_callback_rejects_invalid_state() {
+  let site_url = "https://bar.org";
+  let (_server, state) = setup_fake_oauth_server(site_url).await;
+
+  // A prior login sets the OAuth state cookie.
+  let cookies = Cookies::default();
+  let external_redirect: Redirect = login::login_with_external_auth_provider(
+    State(state.clone()),
+    Path(TestOAuthProvider::NAME.to_string()),
+    Query(LoginInputParams {
+      redirect_uri: Some(format!("{site_url}/login-success-welcome")),
+      mfa_redirect_uri: None,
+      response_type: None,
+      pkce_code_challenge: None,
+    }),
+    cookies.clone(),
+  )
+  .await
+  .unwrap();
+
+  let (location, _) = get_redirect_location(external_redirect);
+  let authorize_url = url::Url::parse(&location.unwrap()).unwrap();
+  let auth_query: AuthQuery = reqwest::get(authorize_url.as_str())
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+  // The form_post callback must reject a response whose state doesn't match the CSRF secret
+  // stored in the state cookie.
+  let result = callback::callback_from_external_auth_provider_post(
+    State(state.clone()),
+    Path(TestOAuthProvider::NAME.to_string()),
+    Extension(HasRoot(false)),
+    cookies.clone(),
+    Form(callback::CallbackQuery {
+      state: "tampered".to_string(),
+      code: Some(auth_query.code_challenge.clone()),
+      error: None,
+    }),
+  )
+  .await;
+  assert!(matches!(
+    result,
+    Err(AuthError::BadRequest("invalid state"))
+  ));
+
+  // Similarly, without a state cookie from a prior login the callback must reject, too.
+  let result = callback::callback_from_external_auth_provider_post(
+    State(state.clone()),
+    Path(TestOAuthProvider::NAME.to_string()),
+    Extension(HasRoot(false)),
+    Cookies::default(),
+    Form(callback::CallbackQuery {
+      state: auth_query.state.clone(),
+      code: Some(auth_query.code_challenge.clone()),
+      error: None,
+    }),
+  )
+  .await;
+  assert!(matches!(
+    result,
+    Err(AuthError::BadRequest("missing state"))
+  ));
+
+  // Providers like Apple report a cancelled consent dialog by submitting `error` + `state`
+  // WITHOUT a `code`: this must reach the provider-error branch (rather than failing form
+  // deserialization) and doesn't require a prior login state.
+  let result = callback::callback_from_external_auth_provider_post(
+    State(state.clone()),
+    Path(TestOAuthProvider::NAME.to_string()),
+    Extension(HasRoot(false)),
+    Cookies::default(),
+    Form(callback::CallbackQuery {
+      state: auth_query.state.clone(),
+      code: None,
+      error: Some("access_denied".to_string()),
+    }),
+  )
+  .await;
+  assert!(matches!(
+    result,
+    Err(AuthError::FailedDependency(err)) if err.to_string() == "access_denied"
+  ));
+
+  // A response with neither `code` nor `error` is rejected with a client error.
+  let result = callback::callback_from_external_auth_provider_post(
+    State(state.clone()),
+    Path(TestOAuthProvider::NAME.to_string()),
+    Extension(HasRoot(false)),
+    Cookies::default(),
+    Form(callback::CallbackQuery {
+      state: auth_query.state.clone(),
+      code: None,
+      error: None,
+    }),
+  )
+  .await;
+  assert!(matches!(result, Err(AuthError::BadRequest("missing code"))));
+}
+
+#[tokio::test]
+async fn test_oauth_form_post_callback_via_http_router() {
+  let site_url = "https://bar.org";
+  let (_server, state) = setup_fake_oauth_server(site_url).await;
+
+  // Build the real OAuth router (as mounted by the server) with the cookie and HasRoot
+  // extension layers.
+  let router: Router = Router::from(crate::auth::oauth::oauth_router())
+    .layer(Extension(HasRoot(false)))
+    .layer(CookieManagerLayer::new())
+    .with_state(state.clone());
+  let server = TestServer::new(router);
+
+  // Trigger a login. Forwarding the resulting state cookie like a browser would: note that
+  // `SameSite=None` cookies require `Secure` and aren't forwarded by the test server's jar
+  // over plain HTTP, so it's passed along manually.
+  let redirect_uri = format!("{site_url}/login-success-welcome");
+  let login_response = server
+    .get(&format!(
+      "/oauth/{}/login?redirect_uri={redirect_uri}",
+      TestOAuthProvider::NAME
+    ))
+    .await;
+  login_response.assert_status(axum::http::StatusCode::SEE_OTHER);
+
+  // Complete the external login like the browser would.
+  let location = login_response
+    .headers()
+    .get("location")
+    .unwrap()
+    .to_str()
+    .unwrap()
+    .to_string();
+  let auth_query: AuthQuery = reqwest::get(&location).await.unwrap().json().await.unwrap();
+
+  // Pretend to be the external provider responding with `response_mode=form_post`: the
+  // callback is reached via a real HTTP POST through the router.
+  let state_cookie = login_response
+    .headers()
+    .get("set-cookie")
+    .unwrap()
+    .to_str()
+    .unwrap()
+    .split(';')
+    .next()
+    .unwrap()
+    .to_string();
+  let callback_response = server
+    .post(&format!("/oauth/{}/callback", TestOAuthProvider::NAME))
+    .add_header("cookie", &state_cookie)
+    .form(&[
+      ("state", auth_query.state.clone()),
+      ("code", auth_query.code_challenge.clone()),
+    ])
+    .await;
+  callback_response.assert_status(axum::http::StatusCode::SEE_OTHER);
+  assert!(
+    callback_response
+      .headers()
+      .get("location")
+      .unwrap()
+      .to_str()
+      .unwrap()
+      .starts_with(&redirect_uri)
   );
 }
 

--- a/crates/core/src/auth/oauth/provider.rs
+++ b/crates/core/src/auth/oauth/provider.rs
@@ -69,6 +69,17 @@ pub trait OAuthProvider {
     AuthType::BasicAuth
   }
 
+  /// Whether the provider responds to the authorization request via
+  /// `response_mode=form_post`, i.e. POSTs the authorization response as a form to our
+  /// callback rather than redirecting with query parameters.
+  ///
+  /// For example, Apple requires `form_post` whenever user-info scopes like `name` or `email`
+  /// are requested:
+  /// https://developer.apple.com/documentation/signinwithapple/incorporating-sign-in-with-apple-into-other-platforms
+  fn uses_form_post_response_mode(&self) -> bool {
+    return false;
+  }
+
   fn settings(&self) -> Result<OAuthClientSettings, AuthError>;
 
   fn oauth_scopes(&self, user_identifier: proto::UserIdentifier) -> Vec<String>;

--- a/crates/core/src/auth/oauth/providers/apple.rs
+++ b/crates/core/src/auth/oauth/providers/apple.rs
@@ -35,12 +35,46 @@ struct ApplePublicKeys {
 pub struct AppleIdToken {
   pub sub: String,
   pub email: Option<String>,
-  pub email_verified: Option<String>,
+  /// Apple sends `email_verified` as a JSON boolean in the id_token, while other
+  /// providers sometimes use the string `"true"`/`"false"`.
+  #[serde(default, deserialize_with = "deserialize_bool_or_string")]
+  pub email_verified: bool,
   // ...Other fields, e.g.:
   // pub aud: String,
   // pub iss: String,
   // pub exp: i64,
   // pub iat: i64,
+}
+
+/// Deserializes a boolean given either as a JSON boolean or as a string, e.g. `"true"`.
+fn deserialize_bool_or_string<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+  D: serde::Deserializer<'de>,
+{
+  struct BoolOrStringVisitor;
+
+  impl<'de> serde::de::Visitor<'de> for BoolOrStringVisitor {
+    type Value = bool;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+      return formatter.write_str("a boolean or a string containing a boolean");
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+      return Ok(value);
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+      // An explicit `null` is treated as absent, i.e. unverified.
+      return Ok(false);
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+      return Ok(value.eq_ignore_ascii_case("true"));
+    }
+  }
+
+  return deserializer.deserialize_any(BoolOrStringVisitor);
 }
 
 /// Apple OAuth2 provider, also known as "Sign-in with Apple".
@@ -80,9 +114,12 @@ impl AppleOAuthProvider {
     http_client: &reqwest::Client,
     id_token: &str,
   ) -> Result<AppleIdToken, AuthError> {
-    let header = jsonwebtoken::decode_header(id_token)
-      .map_err(|err| AuthError::FailedDependency(err.into()))?;
+    let header = jsonwebtoken::decode_header(id_token).map_err(|err| {
+      log::warn!("Apple id_token header could not be decoded: {err}");
+      return AuthError::FailedDependency(err.into());
+    })?;
     let Some(kid) = header.kid else {
+      log::warn!("Apple id_token is missing the kid header");
       return Err(AuthError::FailedDependency(
         "Missing kid in token header".into(),
       ));
@@ -93,6 +130,7 @@ impl AppleOAuthProvider {
 
     // Find the key.
     let Some(public_key) = public_keys.keys.iter().find(|key| key.kid == kid) else {
+      log::warn!("Apple id_token kid '{kid}' not found in Apple's JWKs");
       return Err(AuthError::Unauthorized);
     };
 
@@ -104,7 +142,11 @@ impl AppleOAuthProvider {
     validation.set_issuer(&["https://appleid.apple.com"]);
 
     let token_data = jsonwebtoken::decode::<AppleIdToken>(id_token, &decoding_key, &validation)
-      .map_err(|err| AuthError::FailedDependency(err.into()))?;
+      .map_err(|err| {
+        // Includes signature, audience, issuer, expiry and claims-deserialization errors.
+        log::warn!("Apple id_token verification failed: {err}");
+        return AuthError::FailedDependency(err.into());
+      })?;
 
     return Ok(token_data.claims);
   }
@@ -114,6 +156,18 @@ impl AppleOAuthProvider {
 impl OAuthProvider for AppleOAuthProvider {
   fn name(&self) -> &'static str {
     return Self::NAME;
+  }
+
+  fn auth_type(&self) -> oauth2::AuthType {
+    // Apple only accepts client credentials in the POST body, not via HTTP Basic auth:
+    // https://developer.apple.com/documentation/signinwithapple/request_and_validate_tokens
+    return oauth2::AuthType::RequestBody;
+  }
+
+  fn uses_form_post_response_mode(&self) -> bool {
+    // See the trait documentation: Apple requires form_post whenever user-info scopes are
+    // requested and responds with an auto-submitting form POSTing to our callback handler.
+    return true;
   }
 
   fn provider(&self) -> proto::OAuthProviderId {
@@ -172,7 +226,7 @@ impl OAuthProvider for AppleOAuthProvider {
       provider_id: proto::OAuthProviderId::Apple,
       email: Some(email),
       username: None,
-      verified: apple_id_token.email_verified.is_some_and(|v| v == "true"),
+      verified: apple_id_token.email_verified,
       avatar: None,
     });
   }
@@ -209,5 +263,54 @@ mod tests {
     let settings = provider.settings().unwrap();
     let query: Vec<_> = settings.auth_url.query_pairs().collect();
     assert!(!query.is_empty());
+  }
+
+  #[test]
+  fn test_apple_auth_type_is_request_body() {
+    // Apple only accepts client credentials in the POST body, not HTTP Basic auth.
+    let provider = AppleOAuthProvider {
+      client_id: "12345".to_string(),
+      client_secret: "s3cre7".to_string(),
+    };
+
+    assert!(matches!(
+      provider.auth_type(),
+      oauth2::AuthType::RequestBody
+    ));
+  }
+
+  #[test]
+  fn test_apple_id_token_email_verified_deserialization() {
+    // Apple sends `email_verified` as a JSON boolean in the id_token.
+    let token: AppleIdToken =
+      serde_json::from_str(r#"{"sub":"001","email":"foo@bar.com","email_verified":true}"#).unwrap();
+    assert_eq!(Some("foo@bar.com".to_string()), token.email);
+    assert!(token.email_verified);
+
+    let token: AppleIdToken =
+      serde_json::from_str(r#"{"sub":"001","email_verified":false}"#).unwrap();
+    assert!(!token.email_verified);
+
+    // Some OIDC providers send the flag as a string.
+    let token: AppleIdToken =
+      serde_json::from_str(r#"{"sub":"001","email_verified":"true"}"#).unwrap();
+    assert!(token.email_verified);
+
+    let token: AppleIdToken =
+      serde_json::from_str(r#"{"sub":"001","email_verified":"TRUE"}"#).unwrap();
+    assert!(token.email_verified);
+
+    let token: AppleIdToken =
+      serde_json::from_str(r#"{"sub":"001","email_verified":"false"}"#).unwrap();
+    assert!(!token.email_verified);
+
+    // A missing flag defaults to unverified.
+    let token: AppleIdToken = serde_json::from_str(r#"{"sub":"001"}"#).unwrap();
+    assert!(!token.email_verified);
+
+    // An explicit null is treated as absent, i.e. unverified.
+    let token: AppleIdToken =
+      serde_json::from_str(r#"{"sub":"001","email_verified":null}"#).unwrap();
+    assert!(!token.email_verified);
   }
 }

--- a/crates/core/src/auth/util.rs
+++ b/crates/core/src/auth/util.rs
@@ -235,17 +235,43 @@ pub(crate) fn new_cookie(
   // some o the most blatant XSS attacks, however generally isn't enough. For example,
   // same-origin user-generated content can by-pass this. When cookies are used, forms should
   // also check the CSRF token.
+  return new_cookie_same_site(
+    state,
+    key,
+    value,
+    ttl,
+    if same_site_strict {
+      SameSite::Strict
+    } else {
+      SameSite::Lax
+    },
+  );
+}
+
+/// Cookie with an explicitly chosen `SameSite` policy.
+///
+/// Used, for example, for the OAuth state cookie when the provider responds with
+/// `response_mode=form_post` (e.g. Apple): that response is a cross-site POST navigation
+/// and `SameSite=Lax` cookies are not attached to those. Note that `SameSite=None` requires
+/// the `Secure` attribute, i.e. HTTPS, to be honored by browsers.
+pub(crate) fn new_cookie_same_site(
+  state: &AppState,
+  key: &'static str,
+  value: String,
+  ttl: Duration,
+  same_site: SameSite,
+) -> Cookie<'static> {
   return new_cookie_opts(
     key,
     value,
     ttl,
     /* tls_only= */ secure_tls_only(state),
-    /* same_site_strict= */ same_site_strict,
+    same_site,
   );
 }
 
 #[inline]
-fn secure_tls_only(state: &AppState) -> bool {
+pub(crate) fn secure_tls_only(state: &AppState) -> bool {
   // Be strict in prod-mode and when the site is configured with HTTPS/TLS.
   if state.dev_mode() {
     return false;
@@ -263,7 +289,7 @@ fn new_cookie_opts(
   value: String,
   ttl: Duration,
   tls_only: bool,
-  same_site_strict: bool,
+  same_site: SameSite,
 ) -> Cookie<'static> {
   return Cookie::build((key, value))
     .path("/")
@@ -272,11 +298,7 @@ fn new_cookie_opts(
     // Only send cookie over HTTPs.
     .secure(tls_only)
     // Only include cookie if request originates from origin site.
-    .same_site(if same_site_strict {
-      SameSite::Strict
-    } else {
-      SameSite::Lax
-    })
+    .same_site(same_site)
     .max_age(cookie::time::Duration::seconds(ttl.num_seconds()))
     .build();
 }
@@ -292,7 +314,7 @@ pub(crate) fn remove_cookie(cookies: &Cookies, key: &'static str) {
       "".to_string(),
       Duration::seconds(1),
       /* tls_only= */ false,
-      /* same_site_strict= */ false,
+      SameSite::Lax,
     ));
   }
 }


### PR DESCRIPTION
Continues the best-effort Apple fix from v0.33.6 (#282). We validated the provider end-to-end against a live deployment (real Apple ID, Services ID + .p8 secret, HTTPS) and found the flow still failing after the code exchange. This PR closes the remaining gaps — all changes below were verified against a real deployment.

## What's broken in v0.33.6 (with evidence)

**1. POST callback uses `Json` instead of `Form`.**
Apple's `form_post` response is `application/x-www-form-urlencoded`; the `Json` extractor rejects it, so the POST callback handler never receives Apple's response. Replaced with `Form<CallbackQuery>` (+ `content_type` in the utoipa annotation).

**2. `code` is required, but providers send `error` + `state` without `code` on cancellation.**
E.g. when the user cancels Apple's consent dialog, the form fails to deserialize before the existing `error` branch is ever reached. `code` is now optional; the `error` branch is checked first, a genuinely missing `code` yields `missing code`.

**3. `AppleIdToken.email_verified` is `Option<String>`, but Apple sends a JSON boolean.**
The id_token fails to deserialize right after a *successful* code exchange (the one-time code gets burned) → `424 Failed Dependency`. Deserialization now accepts a boolean, a `"true"/"false"` string, `null`, or a missing value (defaults to unverified).

**4. Token exchange uses HTTP Basic auth (`AuthType::BasicAuth` default).**
Apple only accepts client credentials in the POST body and rejects Basic auth with `invalid_client` (observed in production logs; [docs](https://developer.apple.com/documentation/signinwithapple/generate_and_validate_tokens) specify body parameters). Overrides `auth_type()` to `AuthType::RequestBody` for Apple.

**5. The OAuth state cookie stays `SameSite=Lax`.**
Cross-site POST form submissions don't carry `Lax` cookies; today this only works in Chromium-based browsers thanks to the 2-minute "Lax + POST" exception for freshly set cookies (Safari/Firefox may drop it). The state cookie now uses `SameSite=None` for form_post providers (plus a `warn!` if the site isn't served over HTTPS, since `SameSite=None` requires `Secure` to be honored). Exposed via a new default-off `uses_form_post_response_mode()` trait method.

Also adds `warn!` diagnostics for token-exchange failures and id_token verification errors — without them, the 424 above was indistinguishable from a network failure.

## Tests

- `test_apple_oauth_login_uses_form_post_response_mode`: authorize URL (host/path/`response_mode`/`scope`/`redirect_uri`, `state` roundtrips the CSRF secret) + state cookie is `SameSite=None` & `HttpOnly`.
- `test_oauth_login_flow_with_form_post_callback`: full login flow through the POST handler (form-encoded), incl. regression asserts for redirect-mode providers (no `response_mode`, cookie stays `Lax`).
- `test_oauth_callback_rejects_invalid_state`: tampered `state` → `invalid state`; missing cookie → `missing state`; `error`-only form (cancelled consent) → provider error.
- `test_oauth_form_post_callback_via_http_router`: form POST through the real router.
- `test_apple_auth_type_is_request_body`, `test_apple_id_token_email_verified_deserialization` (bool/string/null/missing).

Full workspace suite unchanged: `cargo test -p trailbase --lib` → 202 passed.

Fixes #282.