### PR TITLE
Fix creating records using default values with Kotlin client

### DIFF
--- a/client/kotlin/lib/src/commonMain/kotlin/Library.kt
+++ b/client/kotlin/lib/src/commonMain/kotlin/Library.kt
@@ -751,6 +751,7 @@ private fun initClient(): HttpClient {
       json(
               Json {
                 ignoreUnknownKeys = true
+                encodeDefaults = true
                 isLenient = true
               }
       )


### PR DESCRIPTION
Hey!

By default, kotlinx serialization doesn't serialize a field if it's the same as the default value.

E.g.
```kt
@Serializable
data class Foo(val x: Int = 3)

Json.encodeToString(Foo())
```
yields an empty dict `{}`.

This cause the issue that when updating a record with a default value, the value does not get sent to the server and we get `db constraint: not null`.

Forcing kotlinx serialization to send default values too this fixes it.