### PR TITLE
Fix table explorer resetting page size on sort/filter

### DIFF
--- a/crates/assets/js/admin/src/components/explorer/TablePane.tsx
+++ b/crates/assets/js/admin/src/components/explorer/TablePane.tsx
@@ -811,10 +811,10 @@ export function TablePane(props: {
     });
   };
   const setFilter = (filter: string | undefined) => {
-    // Reset pagination.
+    // Reset pagination index, but keep the user's chosen page size.
     setSearchParams({
+      ...searchParams,
       pageIndex: undefined,
-      pageSize: undefined,
       filter,
     });
   };
@@ -827,11 +827,10 @@ export function TablePane(props: {
     return [];
   });
   const setSorting = (s: Updater<SortingState>) => {
-    // Reset pagination.
+    // Reset pagination index, but keep the user's chosen page size.
     setSearchParams({
       ...searchParams,
       pageIndex: undefined,
-      pageSize: undefined,
     });
     setSortingImpl(s);
   };


### PR DESCRIPTION
## Summary
- Sorting or filtering the table explorer's data view reset `pageSize` back to the default (20) alongside `pageIndex`, silently discarding a user's chosen page size every time they clicked a column header to sort.
- `TablePane.tsx`'s `setSorting` and `setFilter` both cleared `pageSize` when resetting pagination; only `pageIndex` needs to reset.

## Test plan
- Ran a local disposable TrailBase instance (`--dev`, throwaway depot) with the admin UI dev server against it.
- Created a table with 35 rows, set "per page" to 50, then clicked a column header to sort.
  - Before fix: per-page snapped back to 20.
  - After fix: per-page stayed at 50, sort applied correctly (verified row order and sort arrow indicator).
- Reverted the fix and re-ran the same steps to confirm the regression reproduces, then reapplied it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeT2rHttEQRmRrzTezr1Qa
